### PR TITLE
[CI] Added basic CI for recipes

### DIFF
--- a/.github/workflows/bot.yaml
+++ b/.github/workflows/bot.yaml
@@ -1,0 +1,19 @@
+name: "Post endpoint URL"
+on:
+    pull_request:
+      types: 
+        - opened
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Thanks for contribution! 🎉 \n\n To test the changes please execute: \n ```\ncomposer config extra.symfony.endpoint https://api.github.com/repos/${{ github.repository }}/contents/index.json?ref=flex/pull-${{ github.event.number }}\n```\n before executing the recipes.'
+            })

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+    pull_request: ~
+
+jobs:
+    run-checks:
+        name: Run checks
+        runs-on: ubuntu-20.04
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              id: checkout
+              with:
+                  fetch-depth: 0
+                  ref: 'refs/pull/${{ github.event.number }}/merge'
+
+            - name: Install tools
+              run: |
+                  git config --global user.email ""
+                  git config --global user.name "github-action[bot]"
+                  cd .github
+                  wget -q -O recipes-checker.zip https://codeload.github.com/symfony-tools/recipes-checker/zip/refs/heads/main
+                  unzip recipes-checker.zip
+                  cd recipes-checker-main
+                  composer install --ansi --no-dev
+
+            - name: Check manifest.json files
+              if: "always() && steps.checkout.outcome == 'success'"
+              run: |
+                  .github/recipes-checker-main/run lint:manifests
+
+            - name: Generate Flex testing endpoint
+              if: "always() && steps.checkout.outcome == 'success'"
+              run: |
+                  mkdir .github/flex-endpoint
+                  git ls-tree HEAD */*/* | php .github/recipes-checker-main/run generate:flex-endpoint ${{ github.repository }} master flex/pull-${{ github.event.number }} .github/flex-endpoint
+                  git stash
+                  git switch -c pr
+                  git switch --orphan flex/pull-${{ github.event.number }}
+                  git reset --hard -q
+                  mv .github/flex-endpoint/*.json .
+                  git add *.json
+                  git commit -m 'Create Flex endpoint' || true
+                  git push origin -f flex/pull-${{ github.event.number }}
+                  git switch pr
+                  git stash pop -q || true
+    
+            - name: manifest.json is found
+              if: "always() && steps.checkout.outcome == 'success'"
+              run: |
+                  MISSING=$(find * -mindepth 2 -maxdepth 2 -type d '!' -exec test -f '{}/manifest.json' ';' -print)
+
+                  if [[ "" != "$MISSING" ]]; then echo -e "::error::Recipes must define a \"manifest.json\" file\nFile not found in $MISSING\n"; exit 1; fi
+
+            - name: JSON files are valid
+              if: "always() && steps.checkout.outcome == 'success'"
+              run: |
+                  ERRORS=$(find * -name '*.json' | xargs -n1 -P0 bash -c 'ERR=$(cd / && python -mjson.tool '$(pwd)'/"$0" 2>&1 1> /dev/null) || echo \\n::error file="$0",line=`echo "${ERR#*: line }" | cut -d" " -f 1`::${ERR%%: line *}')
+
+                  if [[ "" != "$ERRORS" ]]; then echo -e "$ERRORS\n"; exit 1; fi
+
+            - name: YAML files are valid
+              if: "always() && steps.checkout.outcome == 'success'"
+              run: |
+                  find * -name '*.yaml' -or -name '*.yml' | .github/recipes-checker-main/run lint:yaml

--- a/.github/workflows/flex-cleanup.yaml
+++ b/.github/workflows/flex-cleanup.yaml
@@ -1,0 +1,17 @@
+name: Cleanup Flex testing endpoint
+
+on:
+    pull_request:
+        types:
+          - closed
+
+jobs:
+    flex-cleanup:
+        name: Cleanup Flex testing endpoint
+        runs-on: ubuntu-20.04
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Cleanup Flex testing endpoint
+              run: git push origin :flex/pull-${{ github.event.number }} || true

--- a/ibexa/commerce/3.3/config/packages/ezplatform_solr.yaml
+++ b/ibexa/commerce/3.3/config/packages/ezplatform_solr.yaml
@@ -1,6 +1,6 @@
 # Base configuration for Solr, for more options see: https://doc.ezplatform.com/en/latest/guide/search/#solr-bundle
 # Can have several connections used by each eZ Repositories in ezplatform.yml
-parameters:
+# parameters:
     # Solr root endpoint, relevant if `solr` is set as search_engine
     #solr_dsn: '%env(SOLR_DSN)%'
     #solr_core: '%env(SOLR_CORE)%'

--- a/ibexa/commerce/4.0/config/packages/ibexa_solr.yaml
+++ b/ibexa/commerce/4.0/config/packages/ibexa_solr.yaml
@@ -1,6 +1,6 @@
 # Base configuration for Solr, for more options see: https://doc.ibexa.co/en/latest/guide/search/search/#solr-bundle
 # Can have several connections used by each Ibexa Repositories in ibexa.yaml
-parameters:
+# parameters:
     # Solr root endpoint, relevant if `solr` is set as search_engine
     #solr_dsn: '%env(SOLR_DSN)%'
     #solr_core: '%env(SOLR_CORE)%'

--- a/ibexa/commerce/4.1/config/packages/ibexa_solr.yaml
+++ b/ibexa/commerce/4.1/config/packages/ibexa_solr.yaml
@@ -1,6 +1,6 @@
 # Base configuration for Solr, for more options see: https://doc.ibexa.co/en/latest/guide/search/search/#solr-bundle
 # Can have several connections used by each Ibexa Repositories in ibexa.yaml
-parameters:
+# parameters:
     # Solr root endpoint, relevant if `solr` is set as search_engine
     #solr_dsn: '%env(SOLR_DSN)%'
     #solr_core: '%env(SOLR_CORE)%'


### PR DESCRIPTION
This PR introduces basic CI for our recipes. It's based on the Symfony workflows, but modified and simplified a bit.

There are three workflows:
1) CI: 
- generates a test endpoint so that changes can be tested before merging. Based on https://github.com/symfony/recipes/blob/main/.github/workflows/callable-qa.yml , but simplified - but we can expand it in the future if we want 😄 

Symfony generates a test endpoint with recipes only for packages that have been changed - I don't think it works in our case, as we would have to use a fallback endpoint all the time for the recipes that are missing in the test endpoint, which seems error-prone.

2) Cleanup:
- based on https://github.com/symfony/recipes/blob/main/.github/workflows/callable-flex-cleanup.yml
- removes the test endpoint branch generated by CI when the Pull Request is closed

3) Bot:
- my own addition
- posts a comment (once, when the PR is opened) saying how to test the endpoint

YAML linter was complaining with:
```
~/De/r/recipes-dev on add-qa-workflows !1 ?2 ❯ find * -name '*.yaml' -or -name '*.yml' | recipes-checker-main/run lint:yaml
::error file=ibexa/commerce/3.3/config/packages/ezplatform_solr.yaml,line=3::"parameters" entry should be removed as it is empty
::error file=ibexa/commerce/4.1/config/packages/ibexa_solr.yaml,line=3::"parameters" entry should be removed as it is empty
::error file=ibexa/commerce/4.0/config/packages/ibexa_solr.yaml,line=3::"parameters" entry should be removed as it is empty
```

So I've decided to comment the whole "parameters" section.