### PR TITLE
IBX-3148: Added prepend encore function

### DIFF
--- a/ibexa/commerce/4.2/encore/ibexa.webpack.config.manager.js
+++ b/ibexa/commerce/4.2/encore/ibexa.webpack.config.manager.js
@@ -56,10 +56,8 @@ const add = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
     config.entry[ibexaEntryName] = [...items, ...newItems];
 };
 const prepend = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
-    const config = ibexaConfig ? ibexaConfig : eZConfig;
-
     const ibexaEntryName = ibexifyEntryName(entryName);
-    const items = findItems(config, ibexaEntryName);
+    const items = findItems(ibexaConfig, ibexaEntryName);
 
     config.entry[ibexaEntryName] = [...newItems, ...items];
 };

--- a/ibexa/commerce/4.2/encore/ibexa.webpack.config.manager.js
+++ b/ibexa/commerce/4.2/encore/ibexa.webpack.config.manager.js
@@ -55,9 +55,18 @@ const add = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
 
     config.entry[ibexaEntryName] = [...items, ...newItems];
 };
+const prepend = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
+    const config = ibexaConfig ? ibexaConfig : eZConfig;
+
+    const ibexaEntryName = ibexifyEntryName(entryName);
+    const items = findItems(config, ibexaEntryName);
+
+    config.entry[ibexaEntryName] = [...newItems, ...items];
+};
 
 module.exports = {
     replace,
     remove,
-    add
+    add,
+    prepend,
 };

--- a/ibexa/commerce/4.2/encore/ibexa.webpack.config.manager.js
+++ b/ibexa/commerce/4.2/encore/ibexa.webpack.config.manager.js
@@ -55,7 +55,7 @@ const add = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
 
     config.entry[ibexaEntryName] = [...items, ...newItems];
 };
-const prepend = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
+const prepend = ({ ibexaConfig, entryName, newItems }) => {
     const ibexaEntryName = ibexifyEntryName(entryName);
     const items = findItems(ibexaConfig, ibexaEntryName);
 

--- a/ibexa/content/4.2/encore/ibexa.webpack.config.manager.js
+++ b/ibexa/content/4.2/encore/ibexa.webpack.config.manager.js
@@ -55,11 +55,9 @@ const add = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
 
     config.entry[ibexaEntryName] = [...items, ...newItems];
 };
-const prepend = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
-    const config = ibexaConfig ? ibexaConfig : eZConfig;
-
+const prepend = ({ ibexaConfig, entryName, newItems }) => {
     const ibexaEntryName = ibexifyEntryName(entryName);
-    const items = findItems(config, ibexaEntryName);
+    const items = findItems(ibexaConfig, ibexaEntryName);
 
     config.entry[ibexaEntryName] = [...newItems, ...items];
 };

--- a/ibexa/content/4.2/encore/ibexa.webpack.config.manager.js
+++ b/ibexa/content/4.2/encore/ibexa.webpack.config.manager.js
@@ -55,9 +55,18 @@ const add = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
 
     config.entry[ibexaEntryName] = [...items, ...newItems];
 };
+const prepend = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
+    const config = ibexaConfig ? ibexaConfig : eZConfig;
+
+    const ibexaEntryName = ibexifyEntryName(entryName);
+    const items = findItems(config, ibexaEntryName);
+
+    config.entry[ibexaEntryName] = [...newItems, ...items];
+};
 
 module.exports = {
     replace,
     remove,
-    add
+    add,
+    prepend,
 };

--- a/ibexa/experience/4.2/encore/ibexa.webpack.config.manager.js
+++ b/ibexa/experience/4.2/encore/ibexa.webpack.config.manager.js
@@ -56,10 +56,8 @@ const add = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
     config.entry[ibexaEntryName] = [...items, ...newItems];
 };
 const prepend = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
-    const config = ibexaConfig ? ibexaConfig : eZConfig;
-
     const ibexaEntryName = ibexifyEntryName(entryName);
-    const items = findItems(config, ibexaEntryName);
+    const items = findItems(ibexaConfig, ibexaEntryName);
 
     config.entry[ibexaEntryName] = [...newItems, ...items];
 };

--- a/ibexa/experience/4.2/encore/ibexa.webpack.config.manager.js
+++ b/ibexa/experience/4.2/encore/ibexa.webpack.config.manager.js
@@ -55,9 +55,18 @@ const add = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
 
     config.entry[ibexaEntryName] = [...items, ...newItems];
 };
+const prepend = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
+    const config = ibexaConfig ? ibexaConfig : eZConfig;
+
+    const ibexaEntryName = ibexifyEntryName(entryName);
+    const items = findItems(config, ibexaEntryName);
+
+    config.entry[ibexaEntryName] = [...newItems, ...items];
+};
 
 module.exports = {
     replace,
     remove,
-    add
+    add,
+    prepend,
 };

--- a/ibexa/experience/4.2/encore/ibexa.webpack.config.manager.js
+++ b/ibexa/experience/4.2/encore/ibexa.webpack.config.manager.js
@@ -55,7 +55,7 @@ const add = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
 
     config.entry[ibexaEntryName] = [...items, ...newItems];
 };
-const prepend = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
+const prepend = ({ ibexaConfig, entryName, newItems }) => {
     const ibexaEntryName = ibexifyEntryName(entryName);
     const items = findItems(ibexaConfig, ibexaEntryName);
 

--- a/ibexa/oss/4.2/encore/ibexa.webpack.config.manager.js
+++ b/ibexa/oss/4.2/encore/ibexa.webpack.config.manager.js
@@ -56,10 +56,8 @@ const add = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
     config.entry[ibexaEntryName] = [...items, ...newItems];
 };
 const prepend = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
-    const config = ibexaConfig ? ibexaConfig : eZConfig;
-
     const ibexaEntryName = ibexifyEntryName(entryName);
-    const items = findItems(config, ibexaEntryName);
+    const items = findItems(ibexaConfig, ibexaEntryName);
 
     config.entry[ibexaEntryName] = [...newItems, ...items];
 };

--- a/ibexa/oss/4.2/encore/ibexa.webpack.config.manager.js
+++ b/ibexa/oss/4.2/encore/ibexa.webpack.config.manager.js
@@ -55,9 +55,18 @@ const add = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
 
     config.entry[ibexaEntryName] = [...items, ...newItems];
 };
+const prepend = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
+    const config = ibexaConfig ? ibexaConfig : eZConfig;
+
+    const ibexaEntryName = ibexifyEntryName(entryName);
+    const items = findItems(config, ibexaEntryName);
+
+    config.entry[ibexaEntryName] = [...newItems, ...items];
+};
 
 module.exports = {
     replace,
     remove,
-    add
+    add,
+    prepend,
 };

--- a/ibexa/oss/4.2/encore/ibexa.webpack.config.manager.js
+++ b/ibexa/oss/4.2/encore/ibexa.webpack.config.manager.js
@@ -55,7 +55,7 @@ const add = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
 
     config.entry[ibexaEntryName] = [...items, ...newItems];
 };
-const prepend = ({ ibexaConfig, eZConfig, entryName, newItems }) => {
+const prepend = ({ ibexaConfig, entryName, newItems }) => {
     const ibexaEntryName = ibexifyEntryName(entryName);
     const items = findItems(ibexaConfig, ibexaEntryName);
 


### PR DESCRIPTION
JIRA issue: https://issues.ibexa.co/browse/IBX-3148

This PR adds `prepend` method to encore config manager, which adds new files at the beginning of JS files, instead of standard ath the end with `add` method. 
Sometimes file has to be included before others, as it adds config required by other file and with only `add` method it was impossible.