### PR TITLE
[ibexa/commerce] Added register configuration

### DIFF
--- a/ibexa/commerce/4.3/config/packages/ibexa.yaml
+++ b/ibexa/commerce/4.3/config/packages/ibexa.yaml
@@ -116,6 +116,9 @@ ibexa:
         site:
             languages: [eng-GB]
             user_content_type_identifier: ['customer']
+            user_registration:
+                user_type_identifier: 'customer'
+                group_id: 57
 
         corporate_group:
             languages: [eng-GB]

--- a/ibexa/commerce/4.4/config/packages/ibexa.yaml
+++ b/ibexa/commerce/4.4/config/packages/ibexa.yaml
@@ -116,6 +116,9 @@ ibexa:
         site:
             languages: [eng-GB]
             user_content_type_identifier: ['customer']
+            user_registration:
+                user_type_identifier: 'customer'
+                group_id: 57
 
         corporate_group:
             languages: [eng-GB]


### PR DESCRIPTION
Related to:
https://github.com/ibexa/commerce-shop/pull/108

As mentioned in:
https://github.com/ibexa/recipes-dev/pull/28#issuecomment-1293271636

`customer` content type is only part of commerce edition, hence it make sense to configure it only on that level instead of package as `commerce-shop` is available in content edition upwards.