### PR TITLE
IBX-3815: Removed Solarium Bundle compatibility

### DIFF
--- a/ibexa/commerce/4.4/config/packages/ibexa_solr.yaml
+++ b/ibexa/commerce/4.4/config/packages/ibexa_solr.yaml
@@ -1,15 +1,14 @@
 # Base configuration for Solr, for more options see: https://doc.ibexa.co/en/latest/guide/search/search/#solr-bundle
 # Can have several connections used by each Ibexa Repositories in ibexa.yaml
-# parameters:
+parameters:
     # Solr root endpoint, relevant if `solr` is set as search_engine
-    #solr_dsn: '%env(SOLR_DSN)%'
-    #solr_core: '%env(SOLR_CORE)%'
+    solr_dsn: '%env(SOLR_DSN)%'
+    solr_core: '%env(SOLR_CORE)%'
 
 ibexa_solr:
     endpoints:
         endpoint0:
-            # suffixed explicitly for compatibility with SolariumBundle used by Commerce
-            dsn: '%solr_dsn%/solr'
+            dsn: '%solr_dsn%'
             core: '%solr_core%'
     connections:
         default:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | IBX-3815
| **Type**                                   | feature
| **Target Ibexa version** | `v4.4`
| **BC breaks**                          | no
| **Doc needed**                       | yes

Aligned ibexa_solr.yaml with ibexa/experience and ibexa/content recipes as we no longer use Solarium Bundle

#### Checklist:
- [X] Provided PR description.
- [ ] Tested the solution manually.
- [X] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).
