### PR TITLE
IBX-3767: Exposed default image variation handler as env variable

### DIFF
--- a/ibexa/commerce/4.4/config/packages/ibexa.yaml
+++ b/ibexa/commerce/4.4/config/packages/ibexa.yaml
@@ -105,6 +105,10 @@ ibexa:
                 purge_servers: ['%purge_server%']
                 varnish_invalidate_token: '%varnish_invalidate_token%'
 
+            # Indicates which handler is used to generate image variations, like `alias` for built-in
+            # or `fastly` for Fastly Image Optimizer or else if you use custom one.
+            variation_handler_identifier: '%env(string:VARIATION_HANDLER_IDENTIFIER)%'
+
             assets:
                 icon_sets:
                     public_icons: /bundles/ibexaadminui/img/ibexa-icons.svg

--- a/ibexa/commerce/4.4/config/packages/ibexa.yaml
+++ b/ibexa/commerce/4.4/config/packages/ibexa.yaml
@@ -107,7 +107,7 @@ ibexa:
 
             # Indicates which handler is used to generate image variations, like `alias` for built-in
             # or `fastly` for Fastly Image Optimizer or else if you use custom one.
-            variation_handler_identifier: '%env(string:VARIATION_HANDLER_IDENTIFIER)%'
+            variation_handler_identifier: '%env(string:IBEXA_VARIATION_HANDLER_IDENTIFIER)%'
 
             assets:
                 icon_sets:

--- a/ibexa/commerce/4.4/manifest.json
+++ b/ibexa/commerce/4.4/manifest.json
@@ -127,7 +127,7 @@
     "#21": "If you have that extension feel free to reconfigure this env value back to 'semaphore'.",
     "#22": "'flock' is safe replacement and is backward compatible. Required by Symfony Rate Limiter.",
     "IBEXA_LOCK_DSN": "flock",
-    "VARIATION_HANDLER_IDENTIFIER": "alias"
+    "IBEXA_VARIATION_HANDLER_IDENTIFIER": "alias"
   },
   "composer-scripts": {
     "cache:clear": "symfony-cmd",

--- a/ibexa/commerce/4.4/manifest.json
+++ b/ibexa/commerce/4.4/manifest.json
@@ -126,7 +126,8 @@
     "#20": "Default LOCK_DSN value (semaphore) makes project require additional 'sysvsem' PHP extension.",
     "#21": "If you have that extension feel free to reconfigure this env value back to 'semaphore'.",
     "#22": "'flock' is safe replacement and is backward compatible. Required by Symfony Rate Limiter.",
-    "IBEXA_LOCK_DSN": "flock"
+    "IBEXA_LOCK_DSN": "flock",
+    "VARIATION_HANDLER_IDENTIFIER": "alias"
   },
   "composer-scripts": {
     "cache:clear": "symfony-cmd",

--- a/ibexa/content/4.4/config/packages/ibexa.yaml
+++ b/ibexa/content/4.4/config/packages/ibexa.yaml
@@ -91,7 +91,7 @@ ibexa:
 
             # Indicates which handler is used to generate image variations, like `alias` for built-in
             # or `fastly` for Fastly Image Optimizer or else if you use custom one.
-            variation_handler_identifier: '%env(string:VARIATION_HANDLER_IDENTIFIER)%'
+            variation_handler_identifier: '%env(string:IBEXA_VARIATION_HANDLER_IDENTIFIER)%'
 
             assets:
                 icon_sets:

--- a/ibexa/content/4.4/config/packages/ibexa.yaml
+++ b/ibexa/content/4.4/config/packages/ibexa.yaml
@@ -89,6 +89,10 @@ ibexa:
                 purge_servers: ['%purge_server%']
                 varnish_invalidate_token: '%varnish_invalidate_token%'
 
+            # Indicates which handler is used to generate image variations, like `alias` for built-in
+            # or `fastly` for Fastly Image Optimizer or else if you use custom one.
+            variation_handler_identifier: '%env(string:VARIATION_HANDLER_IDENTIFIER)%'
+
             assets:
                 icon_sets:
                     public_icons: /bundles/ibexaadminui/img/ibexa-icons.svg

--- a/ibexa/content/4.4/manifest.json
+++ b/ibexa/content/4.4/manifest.json
@@ -110,7 +110,8 @@
     "#14": "In order for this to work you also need to have EzSystemsPlatformFastlyCacheBundle installed",
     "#15": "FASTLY_SERVICE_ID=\"\"",
     "#16": "FASTLY_KEY=\"\"",
-    "IBEXA_EDITION": "content"
+    "IBEXA_EDITION": "content",
+    "VARIATION_HANDLER_IDENTIFIER": "alias"
   },
   "composer-scripts": {
     "cache:clear": "symfony-cmd",

--- a/ibexa/content/4.4/manifest.json
+++ b/ibexa/content/4.4/manifest.json
@@ -111,7 +111,7 @@
     "#15": "FASTLY_SERVICE_ID=\"\"",
     "#16": "FASTLY_KEY=\"\"",
     "IBEXA_EDITION": "content",
-    "VARIATION_HANDLER_IDENTIFIER": "alias"
+    "IBEXA_VARIATION_HANDLER_IDENTIFIER": "alias"
   },
   "composer-scripts": {
     "cache:clear": "symfony-cmd",

--- a/ibexa/experience/4.4/config/packages/ibexa.yaml
+++ b/ibexa/experience/4.4/config/packages/ibexa.yaml
@@ -103,6 +103,10 @@ ibexa:
                 purge_servers: ['%purge_server%']
                 varnish_invalidate_token: '%varnish_invalidate_token%'
 
+            # Indicates which handler is used to generate image variations, like `alias` for built-in
+            # or `fastly` for Fastly Image Optimizer or else if you use custom one.
+            variation_handler_identifier: '%env(string:VARIATION_HANDLER_IDENTIFIER)%'
+
             assets:
                 icon_sets:
                     public_icons: /bundles/ibexaadminui/img/ibexa-icons.svg

--- a/ibexa/experience/4.4/config/packages/ibexa.yaml
+++ b/ibexa/experience/4.4/config/packages/ibexa.yaml
@@ -105,7 +105,7 @@ ibexa:
 
             # Indicates which handler is used to generate image variations, like `alias` for built-in
             # or `fastly` for Fastly Image Optimizer or else if you use custom one.
-            variation_handler_identifier: '%env(string:VARIATION_HANDLER_IDENTIFIER)%'
+            variation_handler_identifier: '%env(string:IBEXA_VARIATION_HANDLER_IDENTIFIER)%'
 
             assets:
                 icon_sets:

--- a/ibexa/experience/4.4/manifest.json
+++ b/ibexa/experience/4.4/manifest.json
@@ -122,7 +122,8 @@
     "#20": "Default LOCK_DSN value (semaphore) makes project require additional 'sysvsem' PHP extension.",
     "#21": "If you have that extension feel free to reconfigure this env value back to 'semaphore'.",
     "#22": "'flock' is safe replacement and is backward compatible. Required by Symfony Rate Limiter.",
-    "IBEXA_LOCK_DSN": "flock"
+    "IBEXA_LOCK_DSN": "flock",
+    "VARIATION_HANDLER_IDENTIFIER": "alias"
   },
   "composer-scripts": {
     "cache:clear": "symfony-cmd",

--- a/ibexa/experience/4.4/manifest.json
+++ b/ibexa/experience/4.4/manifest.json
@@ -123,7 +123,7 @@
     "#21": "If you have that extension feel free to reconfigure this env value back to 'semaphore'.",
     "#22": "'flock' is safe replacement and is backward compatible. Required by Symfony Rate Limiter.",
     "IBEXA_LOCK_DSN": "flock",
-    "VARIATION_HANDLER_IDENTIFIER": "alias"
+    "IBEXA_VARIATION_HANDLER_IDENTIFIER": "alias"
   },
   "composer-scripts": {
     "cache:clear": "symfony-cmd",


### PR DESCRIPTION
Ref: https://github.com/ibexa/core/pull/194

Without exposing it to env variable, local environment would be handicapped to use the same configuration as ie. Platform.sh does (and Fastly IO does not work on local environment).