### PR TITLE
Added missing comment about crucial default `eng-GB` language under `admin_group`

### DIFF
--- a/ibexa/commerce/3.3/config/packages/ezplatform_admin_ui.yaml
+++ b/ibexa/commerce/3.3/config/packages/ezplatform_admin_ui.yaml
@@ -13,6 +13,9 @@ ezplatform:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:

--- a/ibexa/commerce/4.3/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/commerce/4.3/config/packages/ibexa_admin_ui.yaml
@@ -13,6 +13,9 @@ ibexa:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:

--- a/ibexa/commerce/4.4/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/commerce/4.4/config/packages/ibexa_admin_ui.yaml
@@ -13,6 +13,9 @@ ibexa:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:

--- a/ibexa/content/3.3/config/packages/ezplatform_admin_ui.yaml
+++ b/ibexa/content/3.3/config/packages/ezplatform_admin_ui.yaml
@@ -13,6 +13,9 @@ ezplatform:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:

--- a/ibexa/content/4.3/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/content/4.3/config/packages/ibexa_admin_ui.yaml
@@ -13,6 +13,9 @@ ibexa:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:

--- a/ibexa/content/4.4/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/content/4.4/config/packages/ibexa_admin_ui.yaml
@@ -13,6 +13,9 @@ ibexa:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:

--- a/ibexa/experience/3.3/config/packages/ezplatform_admin_ui.yaml
+++ b/ibexa/experience/3.3/config/packages/ezplatform_admin_ui.yaml
@@ -13,6 +13,9 @@ ezplatform:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:

--- a/ibexa/experience/4.3/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/experience/4.3/config/packages/ibexa_admin_ui.yaml
@@ -13,6 +13,9 @@ ibexa:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:

--- a/ibexa/experience/4.4/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/experience/4.4/config/packages/ibexa_admin_ui.yaml
@@ -13,6 +13,9 @@ ibexa:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:

--- a/ibexa/oss/3.3/config/packages/ezplatform_admin_ui.yaml
+++ b/ibexa/oss/3.3/config/packages/ezplatform_admin_ui.yaml
@@ -13,6 +13,9 @@ ezplatform:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:

--- a/ibexa/oss/4.3/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/oss/4.3/config/packages/ibexa_admin_ui.yaml
@@ -13,6 +13,9 @@ ibexa:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:

--- a/ibexa/oss/4.4/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/oss/4.4/config/packages/ibexa_admin_ui.yaml
@@ -13,6 +13,9 @@ ibexa:
 
     system:
         admin_group:
+            # System languages. Note that by default, content, content types, and other data are in eng-GB locale,
+            # so removing eng-GB from this list may lead to errors or content not being shown, unless you change
+            # all eng-GB data to other locales first.
             # For admin this needs to contain all languages you want to translate content to on the given repository.
             languages: [eng-GB]
             content_tree_module:


### PR DESCRIPTION
As the title suggests.