### PR TITLE
IBX-5213: Disable ESI/fragments by default

### DIFF
--- a/ibexa/oss/4.5/config/packages/ibexa.yaml
+++ b/ibexa/oss/4.5/config/packages/ibexa.yaml
@@ -101,6 +101,8 @@ framework:
     translator: { fallback: '%locale_fallback%' }
     validation: { enable_annotations: true }
     default_locale: '%locale_fallback%'
-    esi: true
-    fragments: true
+    esi: false
+    # Be certain that APP_SECRET is set to a long, securely random value generated for this project,
+    # before you enable fragments. Never use the default value that you get out of the box.
+    fragments: false
     http_method_override: true


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-5213

Disable ESI/fragments by default, like they are in Symfony. This is an extra layer of protection when people don't read the install documentation or simply forget to set the APP_SECRET to a secure value. This is intended for 4.5.0, or if that's too much of a BC break, then 5.0.

If approved I'll do the same for content, experience and commerce.