### PR TITLE
[ibexa/commerce] Fixed `IbexaOrderManagementBundle` namespace

### DIFF
--- a/ibexa/commerce/4.5/manifest.json
+++ b/ibexa/commerce/4.5/manifest.json
@@ -77,7 +77,7 @@
     "Ibexa\\Bundle\\FieldTypeAddress\\IbexaFieldTypeAddressBundle": ["all"],
     "Ibexa\\Bundle\\CorporateAccount\\IbexaCorporateAccountBundle": ["all"],
     "Ibexa\\Bundle\\Storefront\\IbexaStorefrontBundle": ["all"],
-    "Ibexa\\Bundle\\Storefront\\IbexaOrderManagementBundle": ["all"]
+    "Ibexa\\Bundle\\OrderManagement\\IbexaOrderManagementBundle": ["all"]
   },
   "copy-from-recipe": {
     "config/": "%CONFIG_DIR%/",


### PR DESCRIPTION
Fix for the namespace wrongly added in https://github.com/ibexa/recipes-dev/pull/58.