### PR TITLE
Added Test Fixtures recipes

### DIFF
--- a/ibexa/test-fixtures/4.6/manifest.json
+++ b/ibexa/test-fixtures/4.6/manifest.json
@@ -1,0 +1,40 @@
+{
+    "aliases": [],
+    "bundles": {
+        "Ibexa\\Bundle\\TestFixtures\\IbexaTestFixturesBundle": ["all"]
+    },
+    "copy-from-package": {
+        "config/headless.yaml": "%CONFIG_DIR%/packages/test_fixtures/headless.yaml",
+        "config/experience.yaml": "%CONFIG_DIR%/packages/test_fixtures/experience.yaml",
+        "config/commerce.yaml": "%CONFIG_DIR%/packages/test_fixtures/commerce.yaml"
+    },
+    "add-lines": [
+        {
+            "file": "config/packages/ibexa.yaml",
+            "content": "imports:",
+            "position": "top",
+            "requires": "ibexa/headless"
+        },
+        {
+            "file": "config/packages/ibexa.yaml",
+            "position": "after_target",
+            "target": "imports:",
+            "content": "  - { resource: test_fixtures/headless.yaml }:",
+            "requires": "ibexa/headless"
+        },
+        {
+            "file": "config/packages/ibexa.yaml",
+            "position": "after_target",
+            "target": "imports:",
+            "content": "  - { resource: test_fixtures/experience.yaml }:",
+            "requires": "ibexa/experience"
+        },
+        {
+            "file": "config/packages/ibexa.yaml",
+            "position": "after_target",
+            "target": "imports:",
+            "content": "  - { resource: test_fixtures/commerce.yaml }:",
+            "requires": "ibexa/commerce"
+        }
+    ]
+}


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-6324

This PR leverages the new `add-lines` configurator to specify configuration based on installed project edition - this means that only some of the files will be enabled when the bundle is installed. 

Moving the configuration part to recipes makes sure that cache is cleared after the package is added, solving a whole range of issues for us.

Requires: https://github.com/ibexa/test-fixtures/pull/45 for the configuration files

Result:

![Zrzut ekranu 2023-08-10 o 11 57 41](https://github.com/ibexa/recipes-dev/assets/10993858/223d6ce0-cc1c-48e1-bfc1-ee9b17bcfaef)


And the configuration files are copied from test-fixtures directly.

![Zrzut ekranu 2023-08-10 o 11 58 34](https://github.com/ibexa/recipes-dev/assets/10993858/512db278-4f4f-47de-8ea9-a870c86eb352)



Doc:
https://github.com/symfony/flex/pull/975
https://github.com/symfony/recipes/blob/544ff21cd02720ce5fa7f2276aa577aaf87eda0b/README.rst#add-lines-configurator