### PR TITLE
[commerce] Moved Payum configuration from bundle

### DIFF
--- a/ibexa/commerce/4.6/config/packages/payum.yaml
+++ b/ibexa/commerce/4.6/config/packages/payum.yaml
@@ -1,0 +1,9 @@
+payum:
+    storages:
+        Ibexa\Payment\Values\Payment:
+            custom: Ibexa\ConnectorPayum\Storage\Payment
+
+    security:
+        token_storage:
+            Ibexa\ConnectorPayum\Token\PaymentToken:
+                doctrine: orm


### PR DESCRIPTION
As configuration file is added from payum recipes, it duplicates (and throws exception) ours from payum-connector.
I have dropped configuration here https://github.com/ibexa/connector-payum/pull/1/commits/62b8d08e0100582c00c601db5adf37e1dcaa7d91 and moved everything at application level.