### PR TITLE
[ibexa/test-fixtures] Added configuration recipe for 4.5

### DIFF
--- a/ibexa/test-fixtures/4.5/manifest.json
+++ b/ibexa/test-fixtures/4.5/manifest.json
@@ -1,0 +1,40 @@
+{
+    "aliases": [],
+    "bundles": {
+        "Ibexa\\Bundle\\TestFixtures\\IbexaTestFixturesBundle": ["all"]
+    },
+    "copy-from-package": {
+        "config/content.yaml": "%CONFIG_DIR%/packages/test_fixtures/content.yaml",
+        "config/experience.yaml": "%CONFIG_DIR%/packages/test_fixtures/experience.yaml",
+        "config/commerce.yaml": "%CONFIG_DIR%/packages/test_fixtures/commerce.yaml"
+    },
+    "add-lines": [
+        {
+            "file": "config/packages/ibexa.yaml",
+            "content": "imports:",
+            "position": "top",
+            "requires": "ibexa/content"
+        },
+        {
+            "file": "config/packages/ibexa.yaml",
+            "position": "after_target",
+            "target": "imports:",
+            "content": "  - { resource: test_fixtures/content.yaml }:",
+            "requires": "ibexa/content"
+        },
+        {
+            "file": "config/packages/ibexa.yaml",
+            "position": "after_target",
+            "target": "imports:",
+            "content": "  - { resource: test_fixtures/experience.yaml }:",
+            "requires": "ibexa/experience"
+        },
+        {
+            "file": "config/packages/ibexa.yaml",
+            "position": "after_target",
+            "target": "imports:",
+            "content": "  - { resource: test_fixtures/commerce.yaml }:",
+            "requires": "ibexa/commerce"
+        }
+    ]
+}


### PR DESCRIPTION
Same as https://github.com/ibexa/recipes-dev/pull/85 , but for 4.5 - it makes no sense to have the configuration in two different formats, it makes upmerges a nightmare.

The only change: `headless` is changed to `content` everywhere.

Requires: https://github.com/ibexa/test-fixtures/pull/54