### PR TITLE
[ibexa/test-fixtures] Moved configuration import to services.yaml

### DIFF
--- a/ibexa/test-fixtures/4.5/manifest.json
+++ b/ibexa/test-fixtures/4.5/manifest.json
@@ -10,30 +10,30 @@
     },
     "add-lines": [
         {
-            "file": "config/packages/ibexa.yaml",
+            "file": "config/services.yaml",
             "content": "imports:",
             "position": "top",
             "requires": "ibexa/content"
         },
         {
-            "file": "config/packages/ibexa.yaml",
+            "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: test_fixtures/content.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/content.yaml }:",
             "requires": "ibexa/content"
         },
         {
-            "file": "config/packages/ibexa.yaml",
+            "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: test_fixtures/experience.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/experience.yaml }:",
             "requires": "ibexa/experience"
         },
         {
-            "file": "config/packages/ibexa.yaml",
+            "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: test_fixtures/commerce.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/commerce.yaml }:",
             "requires": "ibexa/commerce"
         }
     ]

--- a/ibexa/test-fixtures/4.6/manifest.json
+++ b/ibexa/test-fixtures/4.6/manifest.json
@@ -10,30 +10,30 @@
     },
     "add-lines": [
         {
-            "file": "config/packages/ibexa.yaml",
+            "file": "config/services.yaml",
             "content": "imports:",
             "position": "top",
             "requires": "ibexa/headless"
         },
         {
-            "file": "config/packages/ibexa.yaml",
+            "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: test_fixtures/headless.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/headless.yaml }:",
             "requires": "ibexa/headless"
         },
         {
-            "file": "config/packages/ibexa.yaml",
+            "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: test_fixtures/experience.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/experience.yaml }:",
             "requires": "ibexa/experience"
         },
         {
-            "file": "config/packages/ibexa.yaml",
+            "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: test_fixtures/commerce.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/commerce.yaml }:",
             "requires": "ibexa/commerce"
         }
     ]


### PR DESCRIPTION
Required for https://github.com/ibexa/test-fixtures/pull/55

### Issue 
https://github.com/ibexa/test-fixtures/pull/55 uncovered a unpleaseant behaviour in the current configuration setup:

Symfony loads the YAML configuration files in "random"* order, meaning that the two configurations:
- ibexa_site_factory.yaml sets the `enabled` value to `false`
- experience.yaml sets the `enabled` value to `true`

are loaded and merged together - and the Site Factory one is loaded later.

Running:
` php bin/console debug:config ibexa_site_factory` returns:
```
ibexa_site_factory:
    enabled: false
    update_roles:
        - Anonymous
        - Administrator
    templates:
        site_template:
            siteaccess_group: site_factory_group
            name: 'Example Site'
            thumbnail: /bundles/ibexasitefactory/img/template-placeholder.png
            site_skeleton_id: null
            site_skeleton_remote_id: null
            parent_location_id: null
            parent_location_remote_id: null
            user_group_skeleton_ids: {  }
            user_group_skeleton_remote_ids: {  }
        site_template2:
            siteaccess_group: site_factory_group
            name: 'Example Site2'
            thumbnail: /bundles/ibexasitefactory/img/template-placeholder.png
            site_skeleton_id: null
            site_skeleton_remote_id: null
            parent_location_id: null
            parent_location_remote_id: null
            user_group_skeleton_ids: {  }
            user_group_skeleton_remote_ids: {  }
```

As you can see the configuration from https://github.com/ibexa/test-fixtures/pull/55 is applied, but Site Factory is still disabled!

*it's not random, but we can't control it - the Site Factory configuration is loaded after the Test Fixtures one.

### Proposed solution

According to [Symfony doc](https://symfony.com/doc/5.4/configuration.html#configuration-environments):
```
When running the application, Symfony loads the configuration files in this order (the last files can override the values set in the previous ones):

    The files in config/packages/*.<extension>;
    the files in config/packages/<environment-name>/*.<extension>;
    config/services.<extension>;
    config/services_<environment-name>.<extension>.
```

The `services.yaml` file is loaded after all the files from `config/packages` are loaded - meaning it's the best place for us to overwrite values specified in earlier files.

With this solution the Site Factory config is applied correctly:
```
ibexa_site_factory:
    enabled: true
    update_roles:
        - Anonymous
        - Administrator
    templates:
        site_template:
            siteaccess_group: site_factory_group
            name: 'Example Site'
            thumbnail: /bundles/ibexasitefactory/img/template-placeholder.png
            site_skeleton_id: null
            site_skeleton_remote_id: null
            parent_location_id: null
            parent_location_remote_id: null
            user_group_skeleton_ids: {  }
            user_group_skeleton_remote_ids: {  }
        site_template2:
            siteaccess_group: site_factory_group
            name: 'Example Site2'
            thumbnail: /bundles/ibexasitefactory/img/template-placeholder.png
            site_skeleton_id: null
            site_skeleton_remote_id: null
            parent_location_id: null
            parent_location_remote_id: null
            user_group_skeleton_ids: {  }
            user_group_skeleton_remote_ids: {  }
```

