### PR TITLE
IBX-3740: Fixed resolving `ELASTICSEARCH_DSN` variable for Platform.sh

### DIFF
--- a/ibexa/commerce/4.5/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/commerce/4.5/config/packages/ibexa_elasticsearch.yaml
@@ -1,6 +1,7 @@
 # Base configuration for Elasticsearch
 parameters:
-    elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
+    env(ELASTICSEARCH_URL): '%env(ELASTICSEARCH_DSN)%'
+    elasticsearch_dsn: "%env(ELASTICSEARCH_URL)%"
 
 ibexa_elasticsearch:
     connections:

--- a/ibexa/commerce/4.6/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/commerce/4.6/config/packages/ibexa_elasticsearch.yaml
@@ -1,6 +1,7 @@
 # Base configuration for Elasticsearch
 parameters:
-    elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
+    env(ELASTICSEARCH_URL): '%env(ELASTICSEARCH_DSN)%'
+    elasticsearch_dsn: "%env(ELASTICSEARCH_URL)%"
 
 ibexa_elasticsearch:
     connections:

--- a/ibexa/commerce/5.0/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/commerce/5.0/config/packages/ibexa_elasticsearch.yaml
@@ -1,6 +1,7 @@
 # Base configuration for Elasticsearch
 parameters:
-    elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
+    env(ELASTICSEARCH_URL): '%env(ELASTICSEARCH_DSN)%'
+    elasticsearch_dsn: "%env(ELASTICSEARCH_URL)%"
 
 ibexa_elasticsearch:
     connections:

--- a/ibexa/content/4.5/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/content/4.5/config/packages/ibexa_elasticsearch.yaml
@@ -1,6 +1,7 @@
 # Base configuration for Elasticsearch
 parameters:
-    elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
+    env(ELASTICSEARCH_URL): '%env(ELASTICSEARCH_DSN)%'
+    elasticsearch_dsn: "%env(ELASTICSEARCH_URL)%"
 
 ibexa_elasticsearch:
     connections:

--- a/ibexa/experience/4.5/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/experience/4.5/config/packages/ibexa_elasticsearch.yaml
@@ -1,6 +1,7 @@
 # Base configuration for Elasticsearch
 parameters:
-    elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
+    env(ELASTICSEARCH_URL): '%env(ELASTICSEARCH_DSN)%'
+    elasticsearch_dsn: "%env(ELASTICSEARCH_URL)%"
 
 ibexa_elasticsearch:
     connections:

--- a/ibexa/experience/4.6/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/experience/4.6/config/packages/ibexa_elasticsearch.yaml
@@ -1,6 +1,7 @@
 # Base configuration for Elasticsearch
 parameters:
-    elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
+    env(ELASTICSEARCH_URL): '%env(ELASTICSEARCH_DSN)%'
+    elasticsearch_dsn: "%env(ELASTICSEARCH_URL)%"
 
 ibexa_elasticsearch:
     connections:

--- a/ibexa/experience/5.0/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/experience/5.0/config/packages/ibexa_elasticsearch.yaml
@@ -1,6 +1,7 @@
 # Base configuration for Elasticsearch
 parameters:
-    elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
+    env(ELASTICSEARCH_URL): '%env(ELASTICSEARCH_DSN)%'
+    elasticsearch_dsn: "%env(ELASTICSEARCH_URL)%"
 
 ibexa_elasticsearch:
     connections:

--- a/ibexa/headless/4.6/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/headless/4.6/config/packages/ibexa_elasticsearch.yaml
@@ -1,6 +1,7 @@
 # Base configuration for Elasticsearch
 parameters:
-    elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
+    env(ELASTICSEARCH_URL): '%env(ELASTICSEARCH_DSN)%'
+    elasticsearch_dsn: "%env(ELASTICSEARCH_URL)%"
 
 ibexa_elasticsearch:
     connections:

--- a/ibexa/headless/5.0/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/headless/5.0/config/packages/ibexa_elasticsearch.yaml
@@ -1,6 +1,7 @@
 # Base configuration for Elasticsearch
 parameters:
-    elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
+    env(ELASTICSEARCH_URL): '%env(ELASTICSEARCH_DSN)%'
+    elasticsearch_dsn: "%env(ELASTICSEARCH_URL)%"
 
 ibexa_elasticsearch:
     connections:


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-3740

For quite some time, Platform.sh relies on `ELASTICSEARCH_URL` env variable, ref:
https://github.com/platformsh/symfonyflex-bridge/blob/b30d3309a02f770e5aec8db06ce59972253a9d0a/platformsh-flex-env.php#L306. Added fallbacking from `ELASTICSEARCH_DSN` to `ELASTICSEARCH_URL` seems to do the trick and saves developers from necessity to set any additional env variables on their Platform.sh instances.

**Note:**
Performing:
```
1. bin/console ibexa:elasticsearch:put-index-template --overwrite
2. curl -X DELETE 'http://elasticsearch.internal:9200/_all'
3. bin/console ibexa:reindex
```
once, might be necessary for the new configuration to be picked up.