### PR TITLE
[ibexa/experience] Explicitly declared Gregwar\CaptchaBundle in bundl…

### DIFF
--- a/ibexa/experience/4.6/manifest.json
+++ b/ibexa/experience/4.6/manifest.json
@@ -7,6 +7,7 @@
     "Symfony\\Bundle\\SwiftmailerBundle\\SwiftmailerBundle": ["all"],
     "Symfony\\Bundle\\MonologBundle\\MonologBundle": ["all"],
     "Symfony\\WebpackEncoreBundle\\WebpackEncoreBundle": ["all"],
+    "Gregwar\\CaptchaBundle\\GregwarCaptchaBundle": ["all"],
     "Sensio\\Bundle\\FrameworkExtraBundle\\SensioFrameworkExtraBundle": ["all"],
     "Doctrine\\Bundle\\DoctrineBundle\\DoctrineBundle": ["all"],
     "Doctrine\\Bundle\\MigrationsBundle\\DoctrineMigrationsBundle": ["all"],


### PR DESCRIPTION
| Question             | Answer                                                |
|----------------------|-------------------------------------------------------|
| **JIRA issue**       | https://issues.ibexa.co/browse/IBX-7785              |
| **Target Ibexa version**    | `v4.6`                                                |

#### Description:

Seems in some cases, like an upgrade from 4.5.6 to 4.6.2 (executed on the installed version from the tag, not x-dev), since `Gregwar\CaptchaBundle` in not explicitly listed in our bundles manifest, its placement in the bundles list is arbitrary (I'm guessing from some generic Symfony bundles recipe). It needs to be placed after Twig Bundle, because it relies directly on a parameter declared by Twig extension.

$ php bin/console cache:clear

```
In ParameterBag.php line 93:
                                                                      
  You have requested a non-existent parameter "twig.form.resources".
```

We require anyway that bundle in the Product, so maybe there's nothing wrong with declaring it explicitly?
```
$ composer why gregwar/captcha-bundle
ibexa/form-builder v4.6.2 requires  gregwar/captcha-bundle (^2.1)  
ibexa/headless     v4.6.2 requires  gregwar/captcha-bundle (^2.1)
```

#### TODO

- [ ] See if this actually works