### PR TITLE
IBX-8140: Enabled authenticator manager-based security

### DIFF
--- a/ibexa/commerce/5.0/config/packages/security.yaml
+++ b/ibexa/commerce/5.0/config/packages/security.yaml
@@ -27,6 +27,11 @@
 # To get started with security, check out the documentation:
 # https://symfony.com/doc/current/security.html
 security:
+    enable_authenticator_manager: true
+
+    password_hashers:
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
+
     # https://symfony.com/doc/current/security.html#b-configuring-how-users-are-loaded
     providers:
         ibexa:
@@ -128,18 +133,17 @@ security:
         ibexa_front:
             pattern: ^/
             user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
-            anonymous: ~
             ibexa_rest_session: ~
             form_login:
                 require_previous_session: false
-                csrf_token_generator: security.csrf.token_manager
-            guard:
-                authenticator: 'Ibexa\PageBuilder\Security\EditorialMode\TokenAuthenticator'
+                enable_csrf: true
+                login_path: login
+                check_path: login_check
+            entry_point: form_login
             logout:
                 path: logout
 
         main:
-            anonymous: ~
             # activate different ways to authenticate
 
             # https://symfony.com/doc/current/security.html#a-configuring-how-your-users-will-authenticate

--- a/ibexa/experience/5.0/config/packages/security.yaml
+++ b/ibexa/experience/5.0/config/packages/security.yaml
@@ -27,6 +27,11 @@
 # To get started with security, check out the documentation:
 # https://symfony.com/doc/current/security.html
 security:
+    enable_authenticator_manager: true
+
+    password_hashers:
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
+
     # https://symfony.com/doc/current/security.html#b-configuring-how-users-are-loaded
     providers:
         ibexa:
@@ -51,18 +56,6 @@ security:
 
         ibexa_register_from_invitation:
             pattern: /user/from-invite/register|/from-invite/register
-            security: false
-
-        ibexa_corporate_dev:
-            pattern: ^/corporate/(css|images|js)/
-            security: false
-
-        ibexa_corporate_customer_portal_register:
-            pattern: ^/corporate/customer-portal/register
-            security: false
-
-        ibexa_corporate_fieldtype_address:
-            pattern: ^/corporate/address/form/
             security: false
 
         ## Uncomment oauth2_token firewall if you wish to use product as an OAuth2 Server.
@@ -128,17 +121,17 @@ security:
         ibexa_front:
             pattern: ^/
             user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
-            anonymous: ~
             ibexa_rest_session: ~
             form_login:
                 require_previous_session: false
-                csrf_token_generator: security.csrf.token_manager
-            guard:
-                authenticator: 'Ibexa\PageBuilder\Security\EditorialMode\TokenAuthenticator'
-            logout: ~
+                enable_csrf: true
+                login_path: login
+                check_path: login_check
+            entry_point: form_login
+            logout:
+                path: logout
 
         main:
-            anonymous: ~
             # activate different ways to authenticate
 
             # https://symfony.com/doc/current/security.html#a-configuring-how-your-users-will-authenticate

--- a/ibexa/headless/5.0/config/packages/security.yaml
+++ b/ibexa/headless/5.0/config/packages/security.yaml
@@ -27,6 +27,11 @@
 # To get started with security, check out the documentation:
 # https://symfony.com/doc/current/security.html
 security:
+    enable_authenticator_manager: true
+
+    password_hashers:
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
+
     # https://symfony.com/doc/current/security.html#b-configuring-how-users-are-loaded
     providers:
         ibexa:
@@ -116,15 +121,17 @@ security:
         ibexa_front:
             pattern: ^/
             user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
-            anonymous: ~
             ibexa_rest_session: ~
             form_login:
                 require_previous_session: false
-                csrf_token_generator: security.csrf.token_manager
-            logout: ~
+                enable_csrf: true
+                login_path: login
+                check_path: login_check
+            entry_point: form_login
+            logout:
+                path: logout
 
         main:
-            anonymous: ~
             # activate different ways to authenticate
 
             # https://symfony.com/doc/current/security.html#a-configuring-how-your-users-will-authenticate

--- a/ibexa/oss/5.0/config/packages/security.yaml
+++ b/ibexa/oss/5.0/config/packages/security.yaml
@@ -27,6 +27,11 @@
 # To get started with security, check out the documentation:
 # https://symfony.com/doc/current/security.html
 security:
+    enable_authenticator_manager: true
+
+    password_hashers:
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
+
     # https://symfony.com/doc/current/security.html#b-configuring-how-users-are-loaded
     providers:
         ibexa:
@@ -72,15 +77,17 @@ security:
         ibexa_front:
             pattern: ^/
             user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
-            anonymous: ~
             ibexa_rest_session: ~
             form_login:
                 require_previous_session: false
-                csrf_token_generator: security.csrf.token_manager
-            logout: ~
+                enable_csrf: true
+                login_path: login
+                check_path: login_check
+            entry_point: form_login
+            logout:
+                path: logout
 
         main:
-            anonymous: ~
             # activate different ways to authenticate
 
             # https://symfony.com/doc/current/security.html#a-configuring-how-your-users-will-authenticate


### PR DESCRIPTION
| :ticket: Issue | IBX-8140 |
|----------------|-----------|

This PR is about switching to the new authorization mechanism that was introduced as part of Symfony 5.4 release. The main trigger allowing us to rely on the new mechanism from now on is setting `enable_authenticator_manager: true`. All the related PRs adapt the existing codebase and base functionalities like login/logout/redirect to work with the new setup.

**The most important part is not having a token for anonymous users which forces us to revisit the approach to such users. In practice we need to deal with `null` value instead of token for anonymous users.**

#### Related PRs: 
- https://github.com/ibexa/core/pull/368
- https://github.com/ibexa/rest/pull/90
- https://github.com/ibexa/admin-ui/pull/1264

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
We should mention that those changes are **necessary** due to switching to the new auth system coming from Symfony (ref: https://symfony.com/doc/5.x/security.html):
```
Symfony Security has received major changes in 5.3. This article explains the new authenticator-based system (identified by the enable_authenticator_manager: true config option).

Refer to the [5.2 version of this documentation](https://symfony.com/doc/5.2/security.html) if you're still using the legacy security system.
```

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
