### PR TITLE
IBX-8117: [ibexa/rector] Added default configuration for ibexa/rector

### DIFF
--- a/ibexa/rector/5.0/manifest.json
+++ b/ibexa/rector/5.0/manifest.json
@@ -1,0 +1,7 @@
+{
+  "aliases": [],
+  "bundles": {},
+  "copy-from-recipe": {
+    "rector.php": "rector.php"
+  }
+}

--- a/ibexa/rector/5.0/rector.php
+++ b/ibexa/rector/5.0/rector.php
@@ -16,10 +16,10 @@ return static function (RectorConfig $rectorConfig): void {
         ]
     );
 
-    // define sets of rules
+    // define set lists
     $rectorConfig->sets(
         [
-            __DIR__ . '/vendor/ibexa/rector/src/contracts/Sets/ibexa-50.php', // rule set for upgrading to Ibexa DXP 5.0
+            __DIR__ . '/vendor/ibexa/rector/src/contracts/Sets/ibexa-50.php', // set list for upgrading to Ibexa DXP 5.0
         ]
     );
 };

--- a/ibexa/rector/5.0/rector.php
+++ b/ibexa/rector/5.0/rector.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths(
+        [
+            __DIR__ . '/src', // see if it matches your project structure
+            __DIR__ . '/tests',
+        ]
+    );
+
+    // define sets of rules
+    $rectorConfig->sets(
+        [
+            __DIR__ . '/vendor/ibexa/rector/src/contracts/Sets/ibexa-50.php', // rule set for upgrading to Ibexa DXP 5.0
+        ]
+    );
+};


### PR DESCRIPTION
| :ticket: Issue | IBX-8117 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/rector/pull/1

#### Description:
This is default ibexa/rector config file (`./rector.php`) to be installed when installing ibexa/rector package.

#### For QA:

Optionally, confirm that this recipe gets installed when requiring `ibexa/rector`.

#### Documentation:

Possibly needs to be mentioned when documenting rector that this is expected to happen (if we decide to document this outside of the package README).