### PR TITLE
IBX-8324: Reworked JWT editorial bearer in page builder

### DIFF
--- a/ibexa/commerce/5.0/config/packages/ibexa_page_builder.yaml
+++ b/ibexa/commerce/5.0/config/packages/ibexa_page_builder.yaml
@@ -1,6 +1,3 @@
-parameters:
-    ibexa.page_builder.token_authenticator.enabled: true
-
 jms_translation:
     configs:
         page_builder:

--- a/ibexa/commerce/5.0/config/packages/security.yaml
+++ b/ibexa/commerce/5.0/config/packages/security.yaml
@@ -143,6 +143,13 @@ security:
             custom_authenticators:
                 - Ibexa\Rest\Security\Authenticator\RestAuthenticator
 
+        ibexa_fragment:
+            pattern: ^/_fragment
+            user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
+            provider: ibexa
+            custom_authenticators:
+                - Ibexa\PageBuilder\Security\EditorialMode\FragmentAuthenticator
+
         ibexa_front:
             pattern: ^/
             provider: ibexa

--- a/ibexa/commerce/5.0/config/packages/security.yaml
+++ b/ibexa/commerce/5.0/config/packages/security.yaml
@@ -143,13 +143,6 @@ security:
             custom_authenticators:
                 - Ibexa\Rest\Security\Authenticator\RestAuthenticator
 
-        ibexa_fragment:
-            pattern: ^/_fragment
-            user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
-            provider: ibexa
-            custom_authenticators:
-                - Ibexa\PageBuilder\Security\EditorialMode\FragmentAuthenticator
-
         ibexa_front:
             pattern: ^/
             provider: ibexa
@@ -160,6 +153,8 @@ security:
                 enable_csrf: true
                 login_path: login
                 check_path: login_check
+            custom_authenticators:
+                - Ibexa\PageBuilder\Security\EditorialMode\FragmentAuthenticator
             entry_point: form_login
             logout:
                 path: logout

--- a/ibexa/experience/5.0/config/packages/ibexa_page_builder.yaml
+++ b/ibexa/experience/5.0/config/packages/ibexa_page_builder.yaml
@@ -1,6 +1,3 @@
-parameters:
-    ibexa.page_builder.token_authenticator.enabled: true
-
 jms_translation:
     configs:
         page_builder:

--- a/ibexa/experience/5.0/config/packages/security.yaml
+++ b/ibexa/experience/5.0/config/packages/security.yaml
@@ -131,13 +131,6 @@ security:
             custom_authenticators:
                 - Ibexa\Rest\Security\Authenticator\RestAuthenticator
 
-        ibexa_fragment:
-            pattern: ^/_fragment
-            user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
-            provider: ibexa
-            custom_authenticators:
-                - Ibexa\PageBuilder\Security\EditorialMode\FragmentAuthenticator
-
         ibexa_front:
             pattern: ^/
             provider: ibexa
@@ -148,6 +141,8 @@ security:
                 enable_csrf: true
                 login_path: login
                 check_path: login_check
+            custom_authenticators:
+                - Ibexa\PageBuilder\Security\EditorialMode\FragmentAuthenticator
             entry_point: form_login
             logout:
                 path: logout

--- a/ibexa/experience/5.0/config/packages/security.yaml
+++ b/ibexa/experience/5.0/config/packages/security.yaml
@@ -131,6 +131,13 @@ security:
             custom_authenticators:
                 - Ibexa\Rest\Security\Authenticator\RestAuthenticator
 
+        ibexa_fragment:
+            pattern: ^/_fragment
+            user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
+            provider: ibexa
+            custom_authenticators:
+                - Ibexa\PageBuilder\Security\EditorialMode\FragmentAuthenticator
+
         ibexa_front:
             pattern: ^/
             provider: ibexa


### PR DESCRIPTION
| :ticket: Issue | IBX-8324 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/page-builder/pull/388

#### Description:
### ~~Why on earth do we need yet another firewall? 😮‍💨~~ We actually don't, `custom_authenticators` fallback does the trick.
`Symfony\Component\Security\Core\Authentication\Provider\AnonymousAuthenticationProvider` was doing the job before it got deprecated. It means all the `/_fragment` calls were caught and `PermissionResolver::setCurrentUserPreference` was invoked so we were authenticated. Since we cannot rely on this mechanism anymore, I needed to figure out how to make sure we won't be having unauthenticated calls in page builder resulting in login screen redirection.

### Why not `EventSubscriber`?
It just won't work - each call needs to go through built-in Symfony authenticator-based system whereas authentication providers are not to be relied upon anymore. Besides, we don't have any security-related events that are available for subrequests.

### Why the original issue from the JIRA ticket emerges only on Varnish?
`/_fragment` calls are strictly related to ESI calls (`render_esi` Twig helpers for each Page Builder block) - if no reverse proxy is in use we fallback to `render` and no separate calls are there.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
Another `security.yaml` related change.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
