### PR TITLE
IBX-8394: [ibexa/rector] Improved default configuration

### DIFF
--- a/ibexa/rector/5.0/rector.php
+++ b/ibexa/rector/5.0/rector.php
@@ -6,20 +6,18 @@
  */
 declare(strict_types=1);
 
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
 use Rector\Config\RectorConfig;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->paths(
-        [
-            __DIR__ . '/src', // see if it matches your project structure
-            __DIR__ . '/tests',
-        ]
-    );
-
-    // define set lists
-    $rectorConfig->sets(
-        [
-            __DIR__ . '/vendor/ibexa/rector/src/contracts/Sets/ibexa-50.php', // set list for upgrading to Ibexa DXP 5.0
-        ]
-    );
-};
+return RectorConfig::configure()
+   ->withPaths(
+       [
+           __DIR__ . '/src', // see if it matches your project structure
+           __DIR__ . '/tests'
+       ]
+   )
+   ->withSets(
+       [
+           IbexaSetList::IBEXA_50->value // rule set for upgrading to Ibexa DXP 5.0
+       ]
+   );


### PR DESCRIPTION
> [!CAUTION]
> Requires ibexa/rector#6 to be merged first

| :ticket: Issue | IBX-8394 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/rector/pull/6

#### Description:

Changed default configuration recipe to include changes from ibexa/rector#6 - instead of hardcoding path to `./vendor/ibexa/rector/src/contracts/Sets/ibexa-50.php`, an `enum IbexaSetList` has been introduced and used.

I've also aligned the config file with the format showcased ATM by https://getrector.com/documentation.

