### PR TITLE
IBX-8691: Simplified security config for OAuth2 server usages

### DIFF
--- a/ibexa/commerce/5.0/config/packages/security.yaml
+++ b/ibexa/commerce/5.0/config/packages/security.yaml
@@ -123,16 +123,13 @@ security:
         #ibexa_oauth2_front:
         #    pattern: ^/
         #    user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
-        #    anonymous: ~
-        #    ibexa_rest_session: ~
-        #    guard:
-        #        authenticators:
-        #            - Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
-        #            - Ibexa\PageBuilder\Security\EditorialMode\TokenAuthenticator
-        #        entry_point: Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
+        #    custom_authenticators:
+        #        - Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
+        #    entry_point: Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
+        #    context: ibexa_dxp
         #    form_login:
         #        require_previous_session: false
-        #        csrf_token_generator: security.csrf.token_manager
+        #        enable_csrf: true
         #    logout: ~
 
         ibexa_rest:

--- a/ibexa/commerce/5.0/config/packages/security.yaml
+++ b/ibexa/commerce/5.0/config/packages/security.yaml
@@ -139,6 +139,8 @@ security:
             context: ibexa
             custom_authenticators:
                 - Ibexa\Rest\Security\Authenticator\RestAuthenticator
+            #uncomment the line below if you wish the product to act as an Oauth2 Server
+            #oauth2: true
 
         ibexa_front:
             pattern: ^/

--- a/ibexa/experience/5.0/config/packages/security.yaml
+++ b/ibexa/experience/5.0/config/packages/security.yaml
@@ -111,16 +111,13 @@ security:
         #ibexa_oauth2_front:
         #    pattern: ^/
         #    user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
-        #    anonymous: ~
-        #    ibexa_rest_session: ~
-        #    guard:
-        #        authenticators:
-        #            - Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
-        #            - Ibexa\PageBuilder\Security\EditorialMode\TokenAuthenticator
-        #        entry_point: Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
+        #    custom_authenticators:
+        #        - Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
+        #    entry_point: Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
+        #    context: ibexa_dxp
         #    form_login:
         #        require_previous_session: false
-        #        csrf_token_generator: security.csrf.token_manager
+        #        enable_csrf: true
         #    logout: ~
 
         ibexa_rest:

--- a/ibexa/experience/5.0/config/packages/security.yaml
+++ b/ibexa/experience/5.0/config/packages/security.yaml
@@ -127,6 +127,8 @@ security:
             context: ibexa
             custom_authenticators:
                 - Ibexa\Rest\Security\Authenticator\RestAuthenticator
+            #uncomment the line below if you wish the product to act as an Oauth2 Server
+            #oauth2: true
 
         ibexa_front:
             pattern: ^/

--- a/ibexa/headless/5.0/config/packages/security.yaml
+++ b/ibexa/headless/5.0/config/packages/security.yaml
@@ -111,16 +111,13 @@ security:
         #ibexa_oauth2_front:
         #    pattern: ^/
         #    user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
-        #    anonymous: ~
-        #    ibexa_rest_session: ~
-        #    guard:
-        #        authenticators:
-        #            - Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
-        #            - Ibexa\PageBuilder\Security\EditorialMode\TokenAuthenticator
-        #        entry_point: Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
+        #    custom_authenticators:
+        #        - Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
+        #    entry_point: Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
+        #    context: ibexa_dxp
         #    form_login:
         #        require_previous_session: false
-        #        csrf_token_generator: security.csrf.token_manager
+        #        enable_csrf: true
         #    logout: ~
 
         ibexa_rest:

--- a/ibexa/headless/5.0/config/packages/security.yaml
+++ b/ibexa/headless/5.0/config/packages/security.yaml
@@ -127,6 +127,8 @@ security:
             context: ibexa
             custom_authenticators:
                 - Ibexa\Rest\Security\Authenticator\RestAuthenticator
+            #uncomment the line below if you wish the product to act as an Oauth2 Server
+            #oauth2: true
 
         ibexa_front:
             pattern: ^/


### PR DESCRIPTION
| :ticket: Issue | IBX-8691 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/oauth2-server/pull/33

#### Description:
It seems we can get rid of our security layer within `ibexa/oauth2-server` bundle. It comes with simplified firewall configuration as the whole authentication process can be done via 3rd party custom authenticator (`League\Bundle\OAuth2ServerBundle\Security\Authenticator\OAuth2Authenticator`) referenced just via `oauth2: true` key.

Putting that under our recently introduced `ibexa_rest` firewall is intentional - config is easier to read as we basically set up a fallback custom authenticator for OAuth2 server use-cases.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
It seems we can adjust the OAuth2 server documentation accordingly.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
