### PR TITLE
IBX-8657: Reworked CDP security layer to not rely on deprecated guard authenticators

### DIFF
--- a/ibexa/commerce/5.0/config/packages/security.yaml
+++ b/ibexa/commerce/5.0/config/packages/security.yaml
@@ -83,8 +83,8 @@ security:
         # Uncomment `ibexa_cdp` rule if you are using Ibexa CDP connector
         #ibexa_cdp:
         #    pattern: /cdp/webhook
-        #    guard:
-        #        authenticator: 'Ibexa\Cdp\Security\CdpRequestAuthenticator'
+        #    custom_authenticators:
+        #        - 'Ibexa\Cdp\Security\CdpRequestAuthenticator'
         #    stateless: true
 
         # Uncomment the rules below to enable JSON Web Token (JWT) authentication for REST and/or GraphQL

--- a/ibexa/commerce/5.0/config/packages/security.yaml
+++ b/ibexa/commerce/5.0/config/packages/security.yaml
@@ -82,7 +82,7 @@ security:
 
         # Uncomment `ibexa_cdp` rule if you are using Ibexa CDP connector
         #ibexa_cdp:
-        #    pattern: /cdp/webhook
+        #    request_matcher: Ibexa\Cdp\Security\RequestMatcher
         #    custom_authenticators:
         #        - 'Ibexa\Cdp\Security\CdpRequestAuthenticator'
         #    stateless: true

--- a/ibexa/experience/5.0/config/packages/security.yaml
+++ b/ibexa/experience/5.0/config/packages/security.yaml
@@ -71,8 +71,8 @@ security:
         # Uncomment `ibexa_cdp` rule if you are using Ibexa CDP connector
         #ibexa_cdp:
         #    pattern: /cdp/webhook
-        #    guard:
-        #        authenticator: 'Ibexa\Cdp\Security\CdpRequestAuthenticator'
+        #    custom_authenticators:
+        #        - 'Ibexa\Cdp\Security\CdpRequestAuthenticator'
         #    stateless: true
 
         # Uncomment the rules below to enable JSON Web Token (JWT) authentication for REST and/or GraphQL

--- a/ibexa/experience/5.0/config/packages/security.yaml
+++ b/ibexa/experience/5.0/config/packages/security.yaml
@@ -70,7 +70,7 @@ security:
 
         # Uncomment `ibexa_cdp` rule if you are using Ibexa CDP connector
         #ibexa_cdp:
-        #    pattern: /cdp/webhook
+        #    request_matcher: Ibexa\Cdp\Security\RequestMatcher
         #    custom_authenticators:
         #        - 'Ibexa\Cdp\Security\CdpRequestAuthenticator'
         #    stateless: true

--- a/ibexa/headless/5.0/config/packages/security.yaml
+++ b/ibexa/headless/5.0/config/packages/security.yaml
@@ -71,8 +71,8 @@ security:
         # Uncomment `ibexa_cdp` rule if you are using Ibexa CDP connector
         #ibexa_cdp:
         #    pattern: /cdp/webhook
-        #    guard:
-        #        authenticator: 'Ibexa\Cdp\Security\CdpRequestAuthenticator'
+        #    custom_authenticators:
+        #        - 'Ibexa\Cdp\Security\CdpRequestAuthenticator'
         #    stateless: true
 
         # Uncomment the rules below to enable JSON Web Token (JWT) authentication for REST and/or GraphQL

--- a/ibexa/headless/5.0/config/packages/security.yaml
+++ b/ibexa/headless/5.0/config/packages/security.yaml
@@ -70,7 +70,7 @@ security:
 
         # Uncomment `ibexa_cdp` rule if you are using Ibexa CDP connector
         #ibexa_cdp:
-        #    pattern: /cdp/webhook
+        #    request_matcher: Ibexa\Cdp\Security\RequestMatcher
         #    custom_authenticators:
         #        - 'Ibexa\Cdp\Security\CdpRequestAuthenticator'
         #    stateless: true


### PR DESCRIPTION
| :ticket: Issue | IBX-8657 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/cdp/pull/27

#### Description:
This time changes are pretty simple - we only replace deprecated `guard` configuration key with our own, adjusted CDP authenticator implementation.

#### For QA:
The whole flow related to integration with CDP needs to be verified.

#### Documentation:
Config change.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
