### PR TITLE
IBX-8775: Added recipe for ibexa/product-catalog-symbol-attribute

### DIFF
--- a/ibexa/product-catalog-symbol-attribute/4.6/config/ibexa_product_catalog_symbol_attribute.yaml
+++ b/ibexa/product-catalog-symbol-attribute/4.6/config/ibexa_product_catalog_symbol_attribute.yaml
@@ -1,0 +1,10 @@
+# Example configuration for a custom symbol attribute:
+
+#ibexa_product_catalog_symbol_attribute:
+#    formats:
+#        mpn:
+#            name: 'Manufacturer Part Number'
+#            pattern: '/^.*$/'
+#            examples:
+#                - '2N6405G'
+#                - '2N6071BG'

--- a/ibexa/product-catalog-symbol-attribute/4.6/manifest.json
+++ b/ibexa/product-catalog-symbol-attribute/4.6/manifest.json
@@ -1,0 +1,9 @@
+{
+  "aliases": [],
+  "bundles": {
+    "Ibexa\\Bundle\\ProductCatalogSymbolAttribute\\IbexaProductCatalogSymbolAttributeBundle::class": ["all"]
+  },
+  "copy-from-recipe": {
+    "config/": "%CONFIG_DIR%/"
+  }
+}

--- a/ibexa/product-catalog-symbol-attribute/5.0/config/ibexa_product_catalog_symbol_attribute.yaml
+++ b/ibexa/product-catalog-symbol-attribute/5.0/config/ibexa_product_catalog_symbol_attribute.yaml
@@ -1,0 +1,10 @@
+# Example configuration for a custom symbol attribute:
+
+#ibexa_product_catalog_symbol_attribute:
+#    formats:
+#        mpn:
+#            name: 'Manufacturer Part Number'
+#            pattern: '/^.*$/'
+#            examples:
+#                - '2N6405G'
+#                - '2N6071BG'

--- a/ibexa/product-catalog-symbol-attribute/5.0/manifest.json
+++ b/ibexa/product-catalog-symbol-attribute/5.0/manifest.json
@@ -1,0 +1,9 @@
+{
+  "aliases": [],
+  "bundles": {
+    "Ibexa\\Bundle\\ProductCatalogSymbolAttribute\\IbexaProductCatalogSymbolAttributeBundle::class": ["all"]
+  },
+  "copy-from-recipe": {
+    "config/": "%CONFIG_DIR%/"
+  }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-8775 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Added recipe for `ibexa/product-catalog-symbol-attribute` package

#### For QA:
`ibexa/product-catalog-symbol-attribute` package after installation should be configured correctly

#### Documentation:
This PR is part of the `ibexa/product-catalog-symbol-attribute` package documentation. 


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
