### PR TITLE
IBX-8817: Documented `http_basic` authentication config

### DIFF
--- a/ibexa/commerce/5.0/config/packages/security.yaml
+++ b/ibexa/commerce/5.0/config/packages/security.yaml
@@ -134,6 +134,12 @@ security:
         #        enable_csrf: true
         #    logout: ~
 
+        # If you wish to use http_basic authentication, uncomment the firewall below and adjust the pattern to meet your project's requirements.
+        #ibexa_http_basic:
+        #    pattern: ^/
+        #    http_basic:
+        #        realm: Secured Area
+
         ibexa_rest:
             pattern: ^/api/ibexa
             provider: ibexa

--- a/ibexa/experience/5.0/config/packages/security.yaml
+++ b/ibexa/experience/5.0/config/packages/security.yaml
@@ -122,6 +122,12 @@ security:
         #        enable_csrf: true
         #    logout: ~
 
+        # If you wish to use http_basic authentication, uncomment the firewall below and adjust the pattern to meet your project's requirements.
+        #ibexa_http_basic:
+        #    pattern: ^/
+        #    http_basic:
+        #        realm: Secured Area
+
         ibexa_rest:
             pattern: ^/api/ibexa
             provider: ibexa

--- a/ibexa/headless/5.0/config/packages/security.yaml
+++ b/ibexa/headless/5.0/config/packages/security.yaml
@@ -121,6 +121,12 @@ security:
         #        enable_csrf: true
         #    logout: ~
 
+        # If you wish to use http_basic authentication, uncomment the firewall below and adjust the pattern to meet your project's requirements.
+        #ibexa_http_basic:
+        #    pattern: ^/
+        #    http_basic:
+        #        realm: Secured Area
+
         ibexa_rest:
             pattern: ^/api/ibexa
             provider: ibexa

--- a/ibexa/oss/5.0/config/packages/security.yaml
+++ b/ibexa/oss/5.0/config/packages/security.yaml
@@ -79,6 +79,12 @@ security:
         #    stateless: true
         #    jwt: ~
 
+        # If you wish to use http_basic authentication, uncomment the firewall below and adjust the pattern to meet your project's requirements.
+        #ibexa_http_basic:
+        #    pattern: ^/
+        #    http_basic:
+        #        realm: Secured Area
+
         ibexa_rest:
             pattern: ^/api/ibexa
             provider: ibexa


### PR DESCRIPTION
| :ticket: Issue | IBX-8817 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR aims to document how `http_basic` authenticator can be used. All the necessary documentation that needs to be put in place can be found here https://symfony.com/doc/5.x/security.html#http-basic.

The example `ibexa_http_basic` firewall allows authorizing via browser window whenever inaccessible resource is reached by just passing regular user data.

From the technical point of view, all the work is done by built-in Symfony `Symfony\Component\Security\Http\Authenticator\HttpBasicAuthenticator`.

![Zrzut ekranu 2024-08-23 o 12 53 52](https://github.com/user-attachments/assets/4c45a020-2411-4e82-b81d-d90284d53d67)

#### For QA:
To properly check proposed changes one needs to uncomment `ibexa_http_basic` firewall and enter any URL that shouldn't be visible without being logged in using regular credentials (e.g. `/admin/dashboard`). After populating the browser modal with user's data, BO should become usable.

#### Documentation:
I suggest documenting this PR in form of a note which redirects us to the mentioned Symfony doc. Some screenshots might be also useful to better exemplify the actual feature.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
