### PR TITLE
[ibexa/product-catalog-symbol-attribute] Fixed the bundle entry

### DIFF
--- a/ibexa/product-catalog-symbol-attribute/4.6/manifest.json
+++ b/ibexa/product-catalog-symbol-attribute/4.6/manifest.json
@@ -1,7 +1,7 @@
 {
   "aliases": [],
   "bundles": {
-    "Ibexa\\Bundle\\ProductCatalogSymbolAttribute\\IbexaProductCatalogSymbolAttributeBundle::class": ["all"]
+    "Ibexa\\Bundle\\ProductCatalogSymbolAttribute\\IbexaProductCatalogSymbolAttributeBundle": ["all"]
   },
   "copy-from-recipe": {
     "config/": "%CONFIG_DIR%/"

--- a/ibexa/product-catalog-symbol-attribute/5.0/manifest.json
+++ b/ibexa/product-catalog-symbol-attribute/5.0/manifest.json
@@ -1,7 +1,7 @@
 {
   "aliases": [],
   "bundles": {
-    "Ibexa\\Bundle\\ProductCatalogSymbolAttribute\\IbexaProductCatalogSymbolAttributeBundle::class": ["all"]
+    "Ibexa\\Bundle\\ProductCatalogSymbolAttribute\\IbexaProductCatalogSymbolAttributeBundle": ["all"]
   },
   "copy-from-recipe": {
     "config/": "%CONFIG_DIR%/"


### PR DESCRIPTION
If you look at other packages then the `::class` suffix is not used:
https://github.com/ibexa/recipes-dev/blob/master/ibexa/connector-ai/4.6/manifest.json#L4

The current one results in Flex actually adding:
```
    Ibexa\Bundle\ProductCatalogSymbolAttribute\IbexaProductCatalogSymbolAttributeBundle::class::class => ['all' => true],
```
and then failing