### PR TITLE
IBX-8470: Upgraded codebase to Symfony 6

### DIFF
--- a/ibexa/commerce/5.0/manifest.json
+++ b/ibexa/commerce/5.0/manifest.json
@@ -8,9 +8,6 @@
         "Symfony\\WebpackEncoreBundle\\WebpackEncoreBundle": ["all"],
         "Doctrine\\Bundle\\DoctrineBundle\\DoctrineBundle": ["all"],
         "Doctrine\\Bundle\\MigrationsBundle\\DoctrineMigrationsBundle": ["all"],
-        "Sensio\\Bundle\\FrameworkExtraBundle\\SensioFrameworkExtraBundle": [
-            "all"
-        ],
         "FOS\\JsRoutingBundle\\FOSJsRoutingBundle": ["all"],
         "JMS\\TranslationBundle\\JMSTranslationBundle": ["all"],
         "Oneup\\FlysystemBundle\\OneupFlysystemBundle": ["all"],

--- a/ibexa/experience/5.0/manifest.json
+++ b/ibexa/experience/5.0/manifest.json
@@ -11,9 +11,6 @@
         "Symfony\\Bundle\\TwigBundle\\TwigBundle": ["all"],
         "Symfony\\Bundle\\MonologBundle\\MonologBundle": ["all"],
         "Symfony\\WebpackEncoreBundle\\WebpackEncoreBundle": ["all"],
-        "Sensio\\Bundle\\FrameworkExtraBundle\\SensioFrameworkExtraBundle": [
-            "all"
-        ],
         "Doctrine\\Bundle\\DoctrineBundle\\DoctrineBundle": ["all"],
         "Doctrine\\Bundle\\MigrationsBundle\\DoctrineMigrationsBundle": ["all"],
         "Bazinga\\Bundle\\JsTranslationBundle\\BazingaJsTranslationBundle": [

--- a/ibexa/headless/5.0/manifest.json
+++ b/ibexa/headless/5.0/manifest.json
@@ -6,9 +6,6 @@
         "Symfony\\Bundle\\TwigBundle\\TwigBundle": ["all"],
         "Symfony\\Bundle\\MonologBundle\\MonologBundle": ["all"],
         "Symfony\\WebpackEncoreBundle\\WebpackEncoreBundle": ["all"],
-        "Sensio\\Bundle\\FrameworkExtraBundle\\SensioFrameworkExtraBundle": [
-            "all"
-        ],
         "Doctrine\\Bundle\\DoctrineBundle\\DoctrineBundle": ["all"],
         "Doctrine\\Bundle\\MigrationsBundle\\DoctrineMigrationsBundle": ["all"],
         "Bazinga\\Bundle\\JsTranslationBundle\\BazingaJsTranslationBundle": [

--- a/ibexa/oss/5.0/manifest.json
+++ b/ibexa/oss/5.0/manifest.json
@@ -6,7 +6,6 @@
     "Symfony\\Bundle\\TwigBundle\\TwigBundle": ["all"],
     "Symfony\\Bundle\\MonologBundle\\MonologBundle": ["all"],
     "Symfony\\WebpackEncoreBundle\\WebpackEncoreBundle": ["all"],
-    "Sensio\\Bundle\\FrameworkExtraBundle\\SensioFrameworkExtraBundle": ["all"],
     "Doctrine\\Bundle\\DoctrineBundle\\DoctrineBundle": ["all"],
     "Doctrine\\Bundle\\MigrationsBundle\\DoctrineMigrationsBundle": ["all"],
     "Bazinga\\Bundle\\JsTranslationBundle\\BazingaJsTranslationBundle": ["all"],


### PR DESCRIPTION
> [!CAUTION]
> This is a part of bigger set of changes, to be merged together when ready
> - [x] :exclamation:  **Remove TMP commits before merge** :exclamation:

| :ticket: Issue | IBX-8470  |
|----------------|-----------|

#### Description:

This PR bumps Symfony to v6 with codebase upgrades.

Key changes:

- [x] Drop sensio/framework-extra-bundle dependency

#### QA:

Sanities in the form of regression tests.

#### Documentation:

No documentation required.
