### PR TITLE
[ibexa/rector] Backported Ibexa Rector recipe to 4.6

### DIFF
--- a/ibexa/rector/4.6/manifest.json
+++ b/ibexa/rector/4.6/manifest.json
@@ -1,0 +1,7 @@
+{
+  "aliases": [],
+  "bundles": {},
+  "copy-from-recipe": {
+    "rector.php": "rector.php"
+  }
+}

--- a/ibexa/rector/4.6/rector.php
+++ b/ibexa/rector/4.6/rector.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+   ->withPaths(
+       [
+           __DIR__ . '/src', // see if it matches your project structure
+           __DIR__ . '/tests'
+       ]
+   )
+   ->withSets(
+       [
+           IbexaSetList::IBEXA_46->value // rule set for upgrading to Ibexa DXP 4.6
+       ]
+   );


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Related PRs:
- [x] ibexa/rector#30

#### Description:
This PR backports `5.0` configuration to `4.6`. `4.6` branch is already available for `ibexa/rector` package.
Ibexa 5.0 set contains deprecations that should be removed in 4.6 anyway.

There might be some minor differences (like we deprecated something in 5.0 only). We could approach that in several ways:
* ~Keep different contents of `5.0` set list between `4.6` and `5.0` branches in `ibexa/rector` package,~
* Keep a copy of the `5.0` set as the `4.6` set with changes, :heavy_check_mark: chosen solution
* ~Ensure all `5.0` rules are executable on `4.6`.~


**Update Jan 28:** after today's dry run for the presentation the conclusion was that having `IBEXA_46` set would look less confusing in case of 4.6.

**Update Mar 12:** changed PR to use `IbexaSetList::IBEXA_46` set for 4.6.
