### PR TITLE
IBX-9584: Resolved Symfony 6.x deprecations vol. 2

### DIFF
--- a/ibexa/commerce/5.0/config/packages/ibexa.yaml
+++ b/ibexa/commerce/5.0/config/packages/ibexa.yaml
@@ -147,7 +147,7 @@ ibexa:
 
 framework:
     translator: { fallback: '%locale_fallback%' }
-    validation: { enable_annotations: true }
+    validation: { enable_attributes: true }
     default_locale: '%locale_fallback%'
     esi: true
     fragments: true

--- a/ibexa/commerce/5.0/config/packages/security.yaml
+++ b/ibexa/commerce/5.0/config/packages/security.yaml
@@ -128,7 +128,6 @@ security:
         #    entry_point: Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
         #    context: ibexa
         #    form_login:
-        #        require_previous_session: false
         #        enable_csrf: true
         #    logout: ~
 
@@ -154,7 +153,6 @@ security:
             user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
             context: ibexa
             form_login:
-                require_previous_session: false
                 enable_csrf: true
                 login_path: login
                 check_path: login_check

--- a/ibexa/commerce/5.0/config/packages/security.yaml
+++ b/ibexa/commerce/5.0/config/packages/security.yaml
@@ -27,8 +27,6 @@
 # To get started with security, check out the documentation:
 # https://symfony.com/doc/current/security.html
 security:
-    enable_authenticator_manager: true
-
     password_hashers:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
 

--- a/ibexa/experience/5.0/config/packages/ibexa.yaml
+++ b/ibexa/experience/5.0/config/packages/ibexa.yaml
@@ -138,7 +138,7 @@ ibexa:
 
 framework:
     translator: { fallback: '%locale_fallback%' }
-    validation: { enable_annotations: true }
+    validation: { enable_attributes: true }
     default_locale: '%locale_fallback%'
     esi: true
     fragments: true

--- a/ibexa/experience/5.0/config/packages/security.yaml
+++ b/ibexa/experience/5.0/config/packages/security.yaml
@@ -116,7 +116,6 @@ security:
         #    entry_point: Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
         #    context: ibexa
         #    form_login:
-        #        require_previous_session: false
         #        enable_csrf: true
         #    logout: ~
 
@@ -142,7 +141,6 @@ security:
             user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
             context: ibexa
             form_login:
-                require_previous_session: false
                 enable_csrf: true
                 login_path: login
                 check_path: login_check

--- a/ibexa/experience/5.0/config/packages/security.yaml
+++ b/ibexa/experience/5.0/config/packages/security.yaml
@@ -27,8 +27,6 @@
 # To get started with security, check out the documentation:
 # https://symfony.com/doc/current/security.html
 security:
-    enable_authenticator_manager: true
-
     password_hashers:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
 

--- a/ibexa/headless/5.0/config/packages/ibexa.yaml
+++ b/ibexa/headless/5.0/config/packages/ibexa.yaml
@@ -118,7 +118,7 @@ ibexa:
 
 framework:
     translator: { fallback: '%locale_fallback%' }
-    validation: { enable_annotations: true }
+    validation: { enable_attributes: true }
     default_locale: '%locale_fallback%'
     esi: true
     fragments: true

--- a/ibexa/headless/5.0/config/packages/security.yaml
+++ b/ibexa/headless/5.0/config/packages/security.yaml
@@ -115,7 +115,6 @@ security:
         #    entry_point: Ibexa\Bundle\OAuth2Client\Security\Authenticator\OAuth2Authenticator
         #    context: ibexa
         #    form_login:
-        #        require_previous_session: false
         #        enable_csrf: true
         #    logout: ~
 
@@ -141,7 +140,6 @@ security:
             user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
             context: ibexa
             form_login:
-                require_previous_session: false
                 enable_csrf: true
                 login_path: login
                 check_path: login_check

--- a/ibexa/headless/5.0/config/packages/security.yaml
+++ b/ibexa/headless/5.0/config/packages/security.yaml
@@ -27,8 +27,6 @@
 # To get started with security, check out the documentation:
 # https://symfony.com/doc/current/security.html
 security:
-    enable_authenticator_manager: true
-
     password_hashers:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
 

--- a/ibexa/oss/5.0/config/packages/ibexa.yaml
+++ b/ibexa/oss/5.0/config/packages/ibexa.yaml
@@ -106,7 +106,7 @@ ibexa:
 
 framework:
     translator: { fallback: '%locale_fallback%' }
-    validation: { enable_annotations: true }
+    validation: { enable_attributes: true }
     default_locale: '%locale_fallback%'
     esi: true
     fragments: true

--- a/ibexa/oss/5.0/config/packages/security.yaml
+++ b/ibexa/oss/5.0/config/packages/security.yaml
@@ -27,8 +27,6 @@
 # To get started with security, check out the documentation:
 # https://symfony.com/doc/current/security.html
 security:
-    enable_authenticator_manager: true
-
     password_hashers:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
 

--- a/ibexa/oss/5.0/config/packages/security.yaml
+++ b/ibexa/oss/5.0/config/packages/security.yaml
@@ -97,7 +97,6 @@ security:
             user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
             context: ibexa
             form_login:
-                require_previous_session: false
                 enable_csrf: true
                 login_path: login
                 check_path: login_check


### PR DESCRIPTION
| :ticket: Issue | IBX-9584  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Manually fixed deprecation warning for Symfony 6.x:

* Replaced deprecated "enable_annotations" option at "framework.validation" with "enable_attributes"  
* Removed deprecated "enable_authenticator_manager" option from security configuration
* Removed deprecated "require_previous_session" option from security.firewalls.ibexa_front.form_login configuration 


#### For QA:
Sanities.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
