### PR TITLE
[ibexa/test-fixtures] Fixed configuration recipes

### DIFF
--- a/ibexa/test-fixtures/4.5/manifest.json
+++ b/ibexa/test-fixtures/4.5/manifest.json
@@ -19,21 +19,21 @@
             "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: packages/test_fixtures/content.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/content.yaml }",
             "requires": "ibexa/content"
         },
         {
             "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: packages/test_fixtures/experience.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/experience.yaml }",
             "requires": "ibexa/experience"
         },
         {
             "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: packages/test_fixtures/commerce.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/commerce.yaml }",
             "requires": "ibexa/commerce"
         }
     ]

--- a/ibexa/test-fixtures/4.6/manifest.json
+++ b/ibexa/test-fixtures/4.6/manifest.json
@@ -19,21 +19,21 @@
             "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: packages/test_fixtures/headless.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/headless.yaml }",
             "requires": "ibexa/headless"
         },
         {
             "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: packages/test_fixtures/experience.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/experience.yaml }",
             "requires": "ibexa/experience"
         },
         {
             "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: packages/test_fixtures/commerce.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/commerce.yaml }",
             "requires": "ibexa/commerce"
         }
     ]

--- a/ibexa/test-fixtures/5.0/manifest.json
+++ b/ibexa/test-fixtures/5.0/manifest.json
@@ -19,21 +19,21 @@
             "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: packages/test_fixtures/headless.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/headless.yaml }",
             "requires": "ibexa/headless"
         },
         {
             "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: packages/test_fixtures/experience.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/experience.yaml }",
             "requires": "ibexa/experience"
         },
         {
             "file": "config/services.yaml",
             "position": "after_target",
             "target": "imports:",
-            "content": "  - { resource: packages/test_fixtures/commerce.yaml }:",
+            "content": "  - { resource: packages/test_fixtures/commerce.yaml }",
             "requires": "ibexa/commerce"
         }
     ]


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Related PRs: 
- https://github.com/ibexa/test-fixtures/pull/70
- https://github.com/ibexa/recipes-dev/pull/85
- https://github.com/ibexa/recipes-dev/pull/102



#### Description:
Current recipes produce `config/services.yaml` as follows:
```yaml
imports:
  - { resource: packages/test_fixtures/commerce.yaml }:
  - { resource: packages/test_fixtures/experience.yaml }:
  - { resource: packages/test_fixtures/headless.yaml }:
```

That trailing colon causes [a fatal error](https://github.com/ibexa/test-fixtures/actions/runs/13416547742/job/37478660627?pr=70#step:10:2264) when clearing Symfony cache.

#### For QA:

Install test-fixtures to observe the issue.