### PR TITLE
[GHA] Bumped Ubuntu to ubuntu-latest in all workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
     run-checks:
         name: Run checks
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/.github/workflows/flex-cleanup.yaml
+++ b/.github/workflows/flex-cleanup.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
     flex-cleanup:
         name: Cleanup Flex testing endpoint
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v2


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Description:

Ubuntu 20.04 for GHA is in a process of being discontinued.
See the failure on upstream recipes blocking the release process now: https://github.com/ibexa/recipes/actions/runs/13656723063

Updated to `ubuntu-latest` to avoid maintenance cost in the future. Let's see if CI agrees.