### PR TITLE
Fixed wrong REST endpoints path for `4.6`

### DIFF
--- a/ibexa/discounts-codes/4.6/config/routes/ibexa_discounts_codes.yaml
+++ b/ibexa/discounts-codes/4.6/config/routes/ibexa_discounts_codes.yaml
@@ -1,3 +1,3 @@
 ibexa.discounts_codes.rest:
-    resource: '@IbexaDiscountsBundle/Resources/config/routing_rest.yaml'
+    resource: '@IbexaDiscountsCodesBundle/Resources/config/routing_rest.yaml'
     prefix: '%ibexa.rest.path_prefix%'


### PR DESCRIPTION
| :ticket: Issue | - |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Followup for https://github.com/ibexa/recipes-dev/pull/162 where the issue emerges only on `4.6`.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
