### PR TITLE
IBX-9916: Upgrade frontend dependencies

### DIFF
--- a/ibexa/commerce/5.0/config/packages/ibexa_assets.yaml
+++ b/ibexa/commerce/5.0/config/packages/ibexa_assets.yaml
@@ -2,6 +2,8 @@ webpack_encore:
     builds:
         ibexa: "%kernel.project_dir%/public/assets/ibexa/build"
         richtext: "%kernel.project_dir%/public/assets/richtext/build"
+        react: '%kernel.project_dir%/public/assets/react/build'
+        react-dom: '%kernel.project_dir%/public/assets/react-dom/build'
 
 framework:
     assets:

--- a/ibexa/commerce/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/commerce/5.0/encore/ibexa.webpack.config.js
@@ -5,6 +5,10 @@ const configSetups = require('./var/encore/ibexa.config.setup.js');
 const path = require('path');
 
 module.exports = (Encore) => {
+    process.env.NODE_ENV =
+        process.env.NODE_ENV ||
+        (Encore.isProduction() ? 'production' : 'development');
+
     Encore.setOutputPath('public/assets/ibexa/build')
         .setPublicPath('/assets/ibexa/build')
         .addExternals({

--- a/ibexa/commerce/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/commerce/5.0/encore/ibexa.webpack.config.js
@@ -5,9 +5,7 @@ const configSetups = require('./var/encore/ibexa.config.setup.js');
 const path = require('path');
 
 module.exports = (Encore) => {
-    process.env.NODE_ENV =
-        process.env.NODE_ENV ||
-        (Encore.isProduction() ? 'production' : 'development');
+    process.env.NODE_ENV ??= Encore.isProduction() ? 'production' : 'development';
 
     Encore.setOutputPath('public/assets/ibexa/build')
         .setPublicPath('/assets/ibexa/build')

--- a/ibexa/commerce/5.0/encore/package.json
+++ b/ibexa/commerce/5.0/encore/package.json
@@ -15,22 +15,18 @@
     "raw-loader": "^4.0.1",
     "style-loader": "^2.0.0",
     "file-loader": "^6.0.0",
-    "@ckeditor/ckeditor5-alignment": "^40.1.0",
-    "@ckeditor/ckeditor5-build-inline": "^40.1.0",
-    "@ckeditor/ckeditor5-dev-utils": "^39.0.0",
-    "@ckeditor/ckeditor5-widget": "^40.1.0",
-    "@ckeditor/ckeditor5-theme-lark": "^40.1.0",
-    "@ckeditor/ckeditor5-code-block": "^40.1.0",
+    "ckeditor5": "^45.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
     "@svgr/webpack": "^8.1.0",
     "ts-loader": "^9.5.1",
-    "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
     "typescript": "^5.6.3",
     "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#~v1.0.1"
   },
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/experience/5.0/config/packages/ibexa_assets.yaml
+++ b/ibexa/experience/5.0/config/packages/ibexa_assets.yaml
@@ -2,6 +2,8 @@ webpack_encore:
     builds:
         ibexa: "%kernel.project_dir%/public/assets/ibexa/build"
         richtext: "%kernel.project_dir%/public/assets/richtext/build"
+        react: '%kernel.project_dir%/public/assets/react/build'
+        react-dom: '%kernel.project_dir%/public/assets/react-dom/build'
 
 framework:
     assets:

--- a/ibexa/experience/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/experience/5.0/encore/ibexa.webpack.config.js
@@ -5,6 +5,10 @@ const configSetups = require('./var/encore/ibexa.config.setup.js');
 const path = require('path');
 
 module.exports = (Encore) => {
+    process.env.NODE_ENV =
+        process.env.NODE_ENV ||
+        (Encore.isProduction() ? 'production' : 'development');
+
     Encore.setOutputPath('public/assets/ibexa/build')
         .setPublicPath('/assets/ibexa/build')
         .addExternals({

--- a/ibexa/experience/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/experience/5.0/encore/ibexa.webpack.config.js
@@ -5,9 +5,7 @@ const configSetups = require('./var/encore/ibexa.config.setup.js');
 const path = require('path');
 
 module.exports = (Encore) => {
-    process.env.NODE_ENV =
-        process.env.NODE_ENV ||
-        (Encore.isProduction() ? 'production' : 'development');
+    process.env.NODE_ENV ??= Encore.isProduction() ? 'production' : 'development';
 
     Encore.setOutputPath('public/assets/ibexa/build')
         .setPublicPath('/assets/ibexa/build')

--- a/ibexa/experience/5.0/encore/package.json
+++ b/ibexa/experience/5.0/encore/package.json
@@ -15,22 +15,18 @@
     "raw-loader": "^4.0.1",
     "style-loader": "^2.0.0",
     "file-loader": "^6.0.0",
-    "@ckeditor/ckeditor5-alignment": "^40.1.0",
-    "@ckeditor/ckeditor5-build-inline": "^40.1.0",
-    "@ckeditor/ckeditor5-dev-utils": "^39.0.0",
-    "@ckeditor/ckeditor5-widget": "^40.1.0",
-    "@ckeditor/ckeditor5-theme-lark": "^40.1.0",
-    "@ckeditor/ckeditor5-code-block": "^40.1.0",
+    "ckeditor5": "^45.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
     "@svgr/webpack": "^8.1.0",
     "ts-loader": "^9.5.1",
-    "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
     "typescript": "^5.6.3",
     "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#~v1.0.1"
   },
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/headless/5.0/config/packages/ibexa_assets.yaml
+++ b/ibexa/headless/5.0/config/packages/ibexa_assets.yaml
@@ -2,6 +2,8 @@ webpack_encore:
     builds:
         ibexa: "%kernel.project_dir%/public/assets/ibexa/build"
         richtext: "%kernel.project_dir%/public/assets/richtext/build"
+        react: '%kernel.project_dir%/public/assets/react/build'
+        react-dom: '%kernel.project_dir%/public/assets/react-dom/build'
 
 framework:
     assets:

--- a/ibexa/headless/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/headless/5.0/encore/ibexa.webpack.config.js
@@ -5,6 +5,10 @@ const configSetups = require('./var/encore/ibexa.config.setup.js');
 const path = require('path');
 
 module.exports = (Encore) => {
+    process.env.NODE_ENV =
+        process.env.NODE_ENV ||
+        (Encore.isProduction() ? 'production' : 'development');
+
     Encore.setOutputPath('public/assets/ibexa/build')
         .setPublicPath('/assets/ibexa/build')
         .addExternals({

--- a/ibexa/headless/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/headless/5.0/encore/ibexa.webpack.config.js
@@ -5,9 +5,7 @@ const configSetups = require('./var/encore/ibexa.config.setup.js');
 const path = require('path');
 
 module.exports = (Encore) => {
-    process.env.NODE_ENV =
-        process.env.NODE_ENV ||
-        (Encore.isProduction() ? 'production' : 'development');
+    process.env.NODE_ENV ??= Encore.isProduction() ? 'production' : 'development';
 
     Encore.setOutputPath('public/assets/ibexa/build')
         .setPublicPath('/assets/ibexa/build')

--- a/ibexa/headless/5.0/encore/package.json
+++ b/ibexa/headless/5.0/encore/package.json
@@ -15,22 +15,18 @@
     "raw-loader": "^4.0.1",
     "style-loader": "^2.0.0",
     "file-loader": "^6.0.0",
-    "@ckeditor/ckeditor5-alignment": "^40.1.0",
-    "@ckeditor/ckeditor5-build-inline": "^40.1.0",
-    "@ckeditor/ckeditor5-dev-utils": "^39.0.0",
-    "@ckeditor/ckeditor5-widget": "^40.1.0",
-    "@ckeditor/ckeditor5-theme-lark": "^40.1.0",
-    "@ckeditor/ckeditor5-code-block": "^40.1.0",
+    "ckeditor5": "^45.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
     "@svgr/webpack": "^8.1.0",
     "ts-loader": "^9.5.1",
-    "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
     "typescript": "^5.6.3",
     "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#~v1.0.1"
   },
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/oss/5.0/config/packages/ibexa_assets.yaml
+++ b/ibexa/oss/5.0/config/packages/ibexa_assets.yaml
@@ -2,6 +2,8 @@ webpack_encore:
     builds:
         ibexa: "%kernel.project_dir%/public/assets/ibexa/build"
         richtext: "%kernel.project_dir%/public/assets/richtext/build"
+        react: '%kernel.project_dir%/public/assets/react/build'
+        react-dom: '%kernel.project_dir%/public/assets/react-dom/build'
 
 framework:
     assets:

--- a/ibexa/oss/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/oss/5.0/encore/ibexa.webpack.config.js
@@ -5,6 +5,10 @@ const configSetups = require('./var/encore/ibexa.config.setup.js');
 const path = require('path');
 
 module.exports = (Encore) => {
+    process.env.NODE_ENV =
+        process.env.NODE_ENV ||
+        (Encore.isProduction() ? 'production' : 'development');
+
     Encore.setOutputPath('public/assets/ibexa/build')
         .setPublicPath('/assets/ibexa/build')
         .addExternals({

--- a/ibexa/oss/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/oss/5.0/encore/ibexa.webpack.config.js
@@ -5,9 +5,7 @@ const configSetups = require('./var/encore/ibexa.config.setup.js');
 const path = require('path');
 
 module.exports = (Encore) => {
-    process.env.NODE_ENV =
-        process.env.NODE_ENV ||
-        (Encore.isProduction() ? 'production' : 'development');
+    process.env.NODE_ENV ??= Encore.isProduction() ? 'production' : 'development';
 
     Encore.setOutputPath('public/assets/ibexa/build')
         .setPublicPath('/assets/ibexa/build')

--- a/ibexa/oss/5.0/encore/package.json
+++ b/ibexa/oss/5.0/encore/package.json
@@ -14,22 +14,18 @@
     "raw-loader": "^4.0.1",
     "style-loader": "^2.0.0",
     "file-loader": "^6.0.0",
-    "@ckeditor/ckeditor5-alignment": "^40.1.0",
-    "@ckeditor/ckeditor5-build-inline": "^40.1.0",
-    "@ckeditor/ckeditor5-dev-utils": "^39.0.0",
-    "@ckeditor/ckeditor5-widget": "^40.1.0",
-    "@ckeditor/ckeditor5-theme-lark": "^40.1.0",
-    "@ckeditor/ckeditor5-code-block": "^40.1.0",
+    "ckeditor5": "^45.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
     "@svgr/webpack": "^8.1.0",
     "ts-loader": "^9.5.1",
-    "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
     "typescript": "^5.6.3",
     "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#~v1.0.1"
   },
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "license": "UNLICENSED",
   "private": true,


### PR DESCRIPTION
| :ticket: Issue | IBX-9916 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
From now on, it is crucial to use `yarn encore prod` or have `NODE_ENV` set to `production` on the production environment. Using `yarn encore dev` will cause React to load in development version, which is not ideal in a production environment. 
We probably like to have some disclaimer in the upgrade doc for 5.0. // cc @mnocon 


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
