### PR TITLE
IBX-9939: TypeScript aliases for bundles

### DIFF
--- a/ibexa/commerce/5.0/encore/custom.tsconfig.mjs
+++ b/ibexa/commerce/5.0/encore/custom.tsconfig.mjs
@@ -1,0 +1,3 @@
+export default (config) => {
+    return config;
+};

--- a/ibexa/commerce/5.0/encore/ibexa.tsconfig.json
+++ b/ibexa/commerce/5.0/encore/ibexa.tsconfig.json
@@ -1,3 +1,13 @@
 {
-    "extends": "@ibexa/ts-config"
+    "extends": "@ibexa/ts-config",
+    "include": [
+        "vendor/ibexa/**/*"
+    ],
+    "exclude": [
+        "vendor/ibexa/**/node_modules/**/*",
+        "vendor/ibexa/**/vendors/**/*"
+    ],
+    "compilerOptions": {
+        "paths": {}
+    }
 }

--- a/ibexa/commerce/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/commerce/5.0/encore/ibexa.webpack.config.js
@@ -19,7 +19,10 @@ module.exports = (Encore) => {
         })
         .enableSassLoader()
         .enableTypeScriptLoader((tsConfig) => {
-            tsConfig.configFile = path.resolve(__dirname, 'ibexa.tsconfig.json');
+            tsConfig.configFile = path.resolve(__dirname, 'tsconfig.json');
+        })
+        .enableForkedTypeScriptTypesChecking((tsConfig) => {
+            tsConfig.async = true;
         })
         .enableReactPreset()
         .enableSingleRuntimeChunk();

--- a/ibexa/commerce/5.0/encore/package.json
+++ b/ibexa/commerce/5.0/encore/package.json
@@ -1,30 +1,31 @@
 {
   "devDependencies": {
+    "@babel/preset-react": "^7.0.0",
+    "@babel/runtime": "^7.13.10",
+    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
     "@hotwired/stimulus": "^3.0.0",
+    "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#~v1.1.1",
+    "@svgr/webpack": "^8.1.0",
     "@symfony/stimulus-bridge": "^3.0.0",
     "@symfony/webpack-encore": "^5.1.0",
-    "webpack": "^5.99.7",
-    "webpack-cli": "^6.0.1",
-    "@babel/preset-react": "^7.0.0",
+    "@types/react-dom": "^19.1.2",
+    "@types/react": "^19.1.2",
+    "ckeditor5": "^45.0.0",
     "core-js": "^3.0.0",
-    "regenerator-runtime": "^0.13.2",
-    "webpack-notifier": "^1.6.0",
-    "react-collapsible": "^2.5.0",
-    "sass": "^1.49.7",
-    "sass-loader": "^16.0.5",
-    "@babel/runtime": "^7.13.10",
+    "file-loader": "^6.0.0",
+    "fork-ts-checker-webpack-plugin": "^7.0.0",
     "postcss-loader": "^4.3.0",
     "raw-loader": "^4.0.1",
+    "react-collapsible": "^2.5.0",
+    "regenerator-runtime": "^0.13.2",
+    "sass-loader": "^16.0.5",
+    "sass": "^1.49.7",
     "style-loader": "^2.0.0",
-    "file-loader": "^6.0.0",
-    "ckeditor5": "^45.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
-    "@svgr/webpack": "^8.1.0",
     "ts-loader": "^9.5.1",
-    "@types/react": "^19.1.2",
-    "@types/react-dom": "^19.1.2",
     "typescript": "^5.6.3",
-    "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#~v1.0.1"
+    "webpack-cli": "^6.0.1",
+    "webpack-notifier": "^1.6.0",
+    "webpack": "^5.99.7"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -37,5 +38,6 @@
     "dev": "encore dev",
     "watch": "encore dev --watch",
     "build": "encore production --progress"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/ibexa/commerce/5.0/manifest.json
+++ b/ibexa/commerce/5.0/manifest.json
@@ -165,6 +165,7 @@
         "cache:clear": "symfony-cmd",
         "assets:install %PUBLIC_DIR%": "symfony-cmd",
         "yarn install": "script",
+        "yarn ibexa-generate-tsconfig": "script",
         "ibexa:encore:compile --config-name app": "symfony-cmd",
         "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
         "ibexa:encore:compile": "symfony-cmd"

--- a/ibexa/experience/5.0/encore/custom.tsconfig.mjs
+++ b/ibexa/experience/5.0/encore/custom.tsconfig.mjs
@@ -1,0 +1,3 @@
+export default (config) => {
+    return config;
+};

--- a/ibexa/experience/5.0/encore/ibexa.tsconfig.json
+++ b/ibexa/experience/5.0/encore/ibexa.tsconfig.json
@@ -1,3 +1,13 @@
 {
-    "extends": "@ibexa/ts-config"
+    "extends": "@ibexa/ts-config",
+    "include": [
+        "vendor/ibexa/**/*"
+    ],
+    "exclude": [
+        "vendor/ibexa/**/node_modules/**/*",
+        "vendor/ibexa/**/vendors/**/*"
+    ],
+    "compilerOptions": {
+        "paths": {}
+    }
 }

--- a/ibexa/experience/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/experience/5.0/encore/ibexa.webpack.config.js
@@ -19,7 +19,10 @@ module.exports = (Encore) => {
         })
         .enableSassLoader()
         .enableTypeScriptLoader((tsConfig) => {
-            tsConfig.configFile = path.resolve(__dirname, 'ibexa.tsconfig.json');
+            tsConfig.configFile = path.resolve(__dirname, 'tsconfig.json');
+        })
+        .enableForkedTypeScriptTypesChecking((tsConfig) => {
+            tsConfig.async = true;
         })
         .enableReactPreset()
         .enableSingleRuntimeChunk();

--- a/ibexa/experience/5.0/encore/package.json
+++ b/ibexa/experience/5.0/encore/package.json
@@ -1,30 +1,31 @@
 {
   "devDependencies": {
+    "@babel/preset-react": "^7.0.0",
+    "@babel/runtime": "^7.13.10",
+    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
     "@hotwired/stimulus": "^3.0.0",
+    "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#^v1.1.1",
+    "@svgr/webpack": "^8.1.0",
     "@symfony/stimulus-bridge": "^3.0.0",
     "@symfony/webpack-encore": "^5.1.0",
-    "webpack": "^5.99.7",
-    "webpack-cli": "^6.0.1",
-    "@babel/preset-react": "^7.0.0",
+    "@types/react-dom": "^19.1.2",
+    "@types/react": "^19.1.2",
+    "ckeditor5": "^45.0.0",
     "core-js": "^3.0.0",
-    "regenerator-runtime": "^0.13.2",
-    "webpack-notifier": "^1.6.0",
-    "react-collapsible": "^2.5.0",
-    "sass": "^1.49.7",
-    "sass-loader": "^16.0.5",
-    "@babel/runtime": "^7.13.10",
+    "file-loader": "^6.0.0",
+    "fork-ts-checker-webpack-plugin": "^7.0.0",
     "postcss-loader": "^4.3.0",
     "raw-loader": "^4.0.1",
+    "react-collapsible": "^2.5.0",
+    "regenerator-runtime": "^0.13.2",
+    "sass-loader": "^16.0.5",
+    "sass": "^1.49.7",
     "style-loader": "^2.0.0",
-    "file-loader": "^6.0.0",
-    "ckeditor5": "^45.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
-    "@svgr/webpack": "^8.1.0",
     "ts-loader": "^9.5.1",
-    "@types/react": "^19.1.2",
-    "@types/react-dom": "^19.1.2",
     "typescript": "^5.6.3",
-    "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#~v1.0.1"
+    "webpack-cli": "^6.0.1",
+    "webpack-notifier": "^1.6.0",
+    "webpack": "^5.99.7"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -37,5 +38,6 @@
     "dev": "encore dev",
     "watch": "encore dev --watch",
     "build": "encore production --progress"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/ibexa/experience/5.0/manifest.json
+++ b/ibexa/experience/5.0/manifest.json
@@ -158,6 +158,7 @@
         "cache:clear": "symfony-cmd",
         "assets:install %PUBLIC_DIR%": "symfony-cmd",
         "yarn install": "script",
+        "yarn ibexa-generate-tsconfig": "script",
         "ibexa:encore:compile --config-name app": "symfony-cmd",
         "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
         "ibexa:encore:compile": "symfony-cmd"

--- a/ibexa/headless/5.0/encore/custom.tsconfig.mjs
+++ b/ibexa/headless/5.0/encore/custom.tsconfig.mjs
@@ -1,0 +1,3 @@
+export default (config) => {
+    return config;
+};

--- a/ibexa/headless/5.0/encore/ibexa.tsconfig.json
+++ b/ibexa/headless/5.0/encore/ibexa.tsconfig.json
@@ -1,3 +1,13 @@
 {
-    "extends": "@ibexa/ts-config"
+    "extends": "@ibexa/ts-config",
+    "include": [
+        "vendor/ibexa/**/*"
+    ],
+    "exclude": [
+        "vendor/ibexa/**/node_modules/**/*",
+        "vendor/ibexa/**/vendors/**/*"
+    ],
+    "compilerOptions": {
+        "paths": {}
+    }
 }

--- a/ibexa/headless/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/headless/5.0/encore/ibexa.webpack.config.js
@@ -19,7 +19,10 @@ module.exports = (Encore) => {
         })
         .enableSassLoader()
         .enableTypeScriptLoader((tsConfig) => {
-            tsConfig.configFile = path.resolve(__dirname, 'ibexa.tsconfig.json');
+            tsConfig.configFile = path.resolve(__dirname, 'tsconfig.json');
+        })
+        .enableForkedTypeScriptTypesChecking((tsConfig) => {
+            tsConfig.async = true;
         })
         .enableReactPreset()
         .enableSingleRuntimeChunk();

--- a/ibexa/headless/5.0/encore/package.json
+++ b/ibexa/headless/5.0/encore/package.json
@@ -1,30 +1,31 @@
 {
   "devDependencies": {
+    "@babel/preset-react": "^7.0.0",
+    "@babel/runtime": "^7.13.10",
+    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
     "@hotwired/stimulus": "^3.0.0",
+    "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#~v1.1.1",
+    "@svgr/webpack": "^8.1.0",
     "@symfony/stimulus-bridge": "^3.0.0",
     "@symfony/webpack-encore": "^5.1.0",
-    "webpack": "^5.99.7",
-    "webpack-cli": "^6.0.1",
-    "@babel/preset-react": "^7.0.0",
+    "@types/react-dom": "^19.1.2",
+    "@types/react": "^19.1.2",
+    "ckeditor5": "^45.0.0",
     "core-js": "^3.0.0",
-    "regenerator-runtime": "^0.13.2",
-    "webpack-notifier": "^1.6.0",
-    "react-collapsible": "^2.5.0",
-    "sass": "^1.49.7",
-    "sass-loader": "^16.0.5",
-    "@babel/runtime": "^7.13.10",
+    "file-loader": "^6.0.0",
+    "fork-ts-checker-webpack-plugin": "^7.0.0",
     "postcss-loader": "^4.3.0",
     "raw-loader": "^4.0.1",
+    "react-collapsible": "^2.5.0",
+    "regenerator-runtime": "^0.13.2",
+    "sass-loader": "^16.0.5",
+    "sass": "^1.49.7",
     "style-loader": "^2.0.0",
-    "file-loader": "^6.0.0",
-    "ckeditor5": "^45.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
-    "@svgr/webpack": "^8.1.0",
     "ts-loader": "^9.5.1",
-    "@types/react": "^19.1.2",
-    "@types/react-dom": "^19.1.2",
     "typescript": "^5.6.3",
-    "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#~v1.0.1"
+    "webpack-cli": "^6.0.1",
+    "webpack-notifier": "^1.6.0",
+    "webpack": "^5.99.7"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -37,5 +38,6 @@
     "dev": "encore dev",
     "watch": "encore dev --watch",
     "build": "encore production --progress"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/ibexa/headless/5.0/manifest.json
+++ b/ibexa/headless/5.0/manifest.json
@@ -139,6 +139,7 @@
         "cache:clear": "symfony-cmd",
         "assets:install %PUBLIC_DIR%": "symfony-cmd",
         "yarn install": "script",
+        "yarn ibexa-generate-tsconfig": "script",
         "ibexa:encore:compile --config-name app": "symfony-cmd",
         "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
         "ibexa:encore:compile": "symfony-cmd"

--- a/ibexa/oss/5.0/encore/custom.tsconfig.mjs
+++ b/ibexa/oss/5.0/encore/custom.tsconfig.mjs
@@ -1,0 +1,3 @@
+export default (config) => {
+    return config;
+};

--- a/ibexa/oss/5.0/encore/ibexa.tsconfig.json
+++ b/ibexa/oss/5.0/encore/ibexa.tsconfig.json
@@ -1,3 +1,13 @@
 {
-    "extends": "@ibexa/ts-config"
+    "extends": "@ibexa/ts-config",
+    "include": [
+        "vendor/ibexa/**/*"
+    ],
+    "exclude": [
+        "vendor/ibexa/**/node_modules/**/*",
+        "vendor/ibexa/**/vendors/**/*"
+    ],
+    "compilerOptions": {
+        "paths": {}
+    }
 }

--- a/ibexa/oss/5.0/encore/ibexa.webpack.config.js
+++ b/ibexa/oss/5.0/encore/ibexa.webpack.config.js
@@ -19,7 +19,10 @@ module.exports = (Encore) => {
         })
         .enableSassLoader()
         .enableTypeScriptLoader((tsConfig) => {
-            tsConfig.configFile = path.resolve(__dirname, 'ibexa.tsconfig.json');
+            tsConfig.configFile = path.resolve(__dirname, 'tsconfig.json');
+        })
+        .enableForkedTypeScriptTypesChecking((tsConfig) => {
+            tsConfig.async = true;
         })
         .enableReactPreset()
         .enableSingleRuntimeChunk();

--- a/ibexa/oss/5.0/encore/package.json
+++ b/ibexa/oss/5.0/encore/package.json
@@ -1,29 +1,30 @@
 {
   "devDependencies": {
+    "@babel/preset-react": "^7.0.0",
+    "@babel/runtime": "^7.13.10",
+    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
     "@hotwired/stimulus": "^3.0.0",
+    "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#^v1.1.1",
+    "@svgr/webpack": "^8.1.0",
     "@symfony/stimulus-bridge": "^3.0.0",
     "@symfony/webpack-encore": "^5.1.0",
-    "webpack": "^5.99.7",
-    "webpack-cli": "^6.0.1",
+    "@types/react-dom": "^19.1.2",
+    "@types/react": "^19.1.2",
+    "ckeditor5": "^45.0.0",
     "core-js": "^3.0.0",
-    "regenerator-runtime": "^0.13.2",
-    "webpack-notifier": "^1.6.0",
-    "@babel/preset-react": "^7.0.0",
-    "sass": "^1.49.7",
-    "sass-loader": "^16.0.5",
-    "@babel/runtime": "^7.13.10",
+    "file-loader": "^6.0.0",
+    "fork-ts-checker-webpack-plugin": "^7.0.0",
     "postcss-loader": "^4.3.0",
     "raw-loader": "^4.0.1",
+    "regenerator-runtime": "^0.13.2",
+    "sass-loader": "^16.0.5",
+    "sass": "^1.49.7",
     "style-loader": "^2.0.0",
-    "file-loader": "^6.0.0",
-    "ckeditor5": "^45.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^47.0.0",
-    "@svgr/webpack": "^8.1.0",
     "ts-loader": "^9.5.1",
-    "@types/react": "^19.1.2",
-    "@types/react-dom": "^19.1.2",
     "typescript": "^5.6.3",
-    "@ibexa/ts-config": "https://github.com/ibexa/ts-config-ibexa#~v1.0.1"
+    "webpack-cli": "^6.0.1",
+    "webpack-notifier": "^1.6.0",
+    "webpack": "^5.99.7"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -36,5 +37,6 @@
     "dev": "encore dev",
     "watch": "encore dev --watch",
     "build": "encore production --progress"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/ibexa/oss/5.0/manifest.json
+++ b/ibexa/oss/5.0/manifest.json
@@ -89,6 +89,7 @@
     "cache:clear": "symfony-cmd",
     "assets:install %PUBLIC_DIR%": "symfony-cmd",
     "yarn install": "script",
+    "yarn ibexa-generate-tsconfig": "script",
     "ibexa:encore:compile --config-name app": "symfony-cmd",
     "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
     "ibexa:encore:compile": "symfony-cmd"


### PR DESCRIPTION
| :ticket: Issue | IBX-9939 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
In all `package.json` there's only `"fork-ts-checker-webpack-plugin": "^7.0.0",` added, rest changes is just sorted of dependencies.
And `@ibexa/ts-config` package was updated to v1.1

I've changed approach of generating aliases to handle case of using addons which adds their own addons. Now tsconfig.json is generating automatically with post-update-cmd and if developer wants to overwrite our config from ibexa.tsconfig.json he can use file `custom.tsconfig.mjs` to overwrite specific parts of it.
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)AA
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 