### PR TITLE
IBX-8471: [ibexa/behat] Configured optional secret for Behat tests

### DIFF
--- a/ibexa/behat/5.0/.env.behat
+++ b/ibexa/behat/5.0/.env.behat
@@ -1,0 +1,1 @@
+APP_SECRET='$ecretf0rt3st'

--- a/ibexa/behat/5.0/manifest.json
+++ b/ibexa/behat/5.0/manifest.json
@@ -11,6 +11,7 @@
         "behat_ibexa_commerce.yaml": "behat_ibexa_commerce.yaml"
     },
     "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/"
+        "config/": "%CONFIG_DIR%/",
+        ".env.behat": ".env.behat"
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8471 |
|----------------|----------|

 
#### Related PRs: 
- https://github.com/ibexa/http-cache/pull/68


#### Description:

Seems like some part of rendering embedded content through ESI requires setting optional APP_SECRET in Symfony 7.2.
Therefore, behat tests for http-cache fail with the following exception:

![image](https://github.com/user-attachments/assets/0b1ae945-fa9b-4c31-a629-cc661475cae9)

Adding to the recipes dummy `.env.behat` with configured `APP_SECRET`.

See https://symfony.com/blog/new-in-symfony-7-2-optional-secret for more details.

#### For QA:

Passing http-cache Browser tests jobs are enough.