### PR TITLE
IBX-9959: Shifted autoloading of ibexa/collaboration and ibexa/share from recipe to edition manifests

### DIFF
--- a/ibexa/collaboration/5.0/manifest.json
+++ b/ibexa/collaboration/5.0/manifest.json
@@ -1,8 +1,6 @@
 {
     "aliases": [],
-    "bundles": {
-        "Ibexa\\Bundle\\Collaboration\\IbexaCollaborationBundle": ["all"]
-    },
+    "bundles": {},
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
     }

--- a/ibexa/commerce/5.0/manifest.json
+++ b/ibexa/commerce/5.0/manifest.json
@@ -83,6 +83,8 @@
         "Ibexa\\Bundle\\OAuth2Client\\IbexaOAuth2ClientBundle": ["all"],
         "Ibexa\\Bundle\\ProductCatalog\\IbexaProductCatalogBundle": ["all"],
         "Ibexa\\Bundle\\Cart\\IbexaCartBundle": ["all"],
+        "Ibexa\\Bundle\\Collaboration\\IbexaCollaborationBundle": ["all"],
+        "Ibexa\\Bundle\\Share\\IbexaShareBundle": ["all"],
         "Ibexa\\Bundle\\Checkout\\IbexaCheckoutBundle": ["all"],
         "Ibexa\\Bundle\\Taxonomy\\IbexaTaxonomyBundle": ["all"],
         "Ibexa\\Bundle\\TreeBuilder\\IbexaTreeBuilderBundle": ["all"],

--- a/ibexa/experience/5.0/manifest.json
+++ b/ibexa/experience/5.0/manifest.json
@@ -86,6 +86,8 @@
         ],
         "Ibexa\\Bundle\\OAuth2Client\\IbexaOAuth2ClientBundle": ["all"],
         "Ibexa\\Bundle\\ProductCatalog\\IbexaProductCatalogBundle": ["all"],
+        "Ibexa\\Bundle\\Collaboration\\IbexaCollaborationBundle": ["all"],
+        "Ibexa\\Bundle\\Share\\IbexaShareBundle": ["all"],
         "Ibexa\\Bundle\\Taxonomy\\IbexaTaxonomyBundle": ["all"],
         "Ibexa\\Bundle\\TreeBuilder\\IbexaTreeBuilderBundle": ["all"],
         "Ibexa\\Bundle\\ContentTree\\IbexaContentTreeBundle": ["all"],

--- a/ibexa/headless/5.0/manifest.json
+++ b/ibexa/headless/5.0/manifest.json
@@ -75,6 +75,8 @@
         ],
         "Ibexa\\Bundle\\OAuth2Client\\IbexaOAuth2ClientBundle": ["all"],
         "Ibexa\\Bundle\\ProductCatalog\\IbexaProductCatalogBundle": ["all"],
+        "Ibexa\\Bundle\\Collaboration\\IbexaCollaborationBundle": ["all"],
+        "Ibexa\\Bundle\\Share\\IbexaShareBundle": ["all"],
         "Ibexa\\Bundle\\Taxonomy\\IbexaTaxonomyBundle": ["all"],
         "Ibexa\\Bundle\\TreeBuilder\\IbexaTreeBuilderBundle": ["all"],
         "Ibexa\\Bundle\\ContentTree\\IbexaContentTreeBundle": ["all"],

--- a/ibexa/share/5.0/manifest.json
+++ b/ibexa/share/5.0/manifest.json
@@ -1,9 +1,4 @@
 {
     "aliases": [],
-    "bundles": {
-        "Ibexa\\Bundle\\Share\\IbexaShareBundle": ["all"]
-    },
-    "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/"
-    }
+    "bundles": {}
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-9959 |
|----------------|----------|

#### Description:
This pull request updates the product core recipe manifest by removing automatic bundle registration for the ibexa/collaboration and ibexa/share packages.

- Cleared the "bundles" section in manifest.json to stop auto-loading these bundles in the core recipe.
- Added these bundles to the edition manifests (commerce, expr, headless) to ensure proper loading based on project edition.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
