### PR TITLE
IBX-9958: Removed ibexa/discounts and ibexa/discount-codes autoload from recipe manifest

### DIFF
--- a/ibexa/discounts-codes/5.0/manifest.json
+++ b/ibexa/discounts-codes/5.0/manifest.json
@@ -1,8 +1,6 @@
 {
   "aliases": [],
-  "bundles": {
-    "Ibexa\\Bundle\\DiscountsCodes\\IbexaDiscountsCodesBundle": ["all"]
-  },
+  "bundles": {},
   "copy-from-recipe": {
     "config/": "%CONFIG_DIR%/"
   }

--- a/ibexa/discounts/5.0/manifest.json
+++ b/ibexa/discounts/5.0/manifest.json
@@ -1,8 +1,6 @@
 {
   "aliases": [],
-  "bundles": {
-    "Ibexa\\Bundle\\Discounts\\IbexaDiscountsBundle": ["all"]
-  },
+  "bundles": {},
   "copy-from-recipe": {
     "config/": "%CONFIG_DIR%/"
   }


### PR DESCRIPTION
| :ticket: Issue | IBX-9958 |
|----------------|----------|

#### Description:
This pull request updates the product core recipe manifest by removing automatic bundle registration for the ibexa/discounts and ibexa/discount-codes packages.

- Cleared the "bundles" section in manifest.json to stop auto-loading these bundles.

Context:
These packages were previously added to the composer.json as part of IBX-9958 to enable discount-related functionality in Product Core. However, recipe-based auto-registration is not required — configuration can be applied manually or at the project level as needed.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
