### PR TITLE
IBX-9957: Shifted autoloading of ibexa/product-catalog-date-and-time-attribute from recipe to edition manifests

### DIFF
--- a/ibexa/commerce/5.0/manifest.json
+++ b/ibexa/commerce/5.0/manifest.json
@@ -82,6 +82,7 @@
         "Ibexa\\Bundle\\ImageEditor\\IbexaImageEditorBundle": ["all"],
         "Ibexa\\Bundle\\OAuth2Client\\IbexaOAuth2ClientBundle": ["all"],
         "Ibexa\\Bundle\\ProductCatalog\\IbexaProductCatalogBundle": ["all"],
+        "Ibexa\\Bundle\\ProductCatalogDateTimeAttribute\\IbexaProductCatalogDateTimeAttributeBundle": ["all"],
         "Ibexa\\Bundle\\Cart\\IbexaCartBundle": ["all"],
         "Ibexa\\Bundle\\Checkout\\IbexaCheckoutBundle": ["all"],
         "Ibexa\\Bundle\\Taxonomy\\IbexaTaxonomyBundle": ["all"],

--- a/ibexa/experience/5.0/manifest.json
+++ b/ibexa/experience/5.0/manifest.json
@@ -86,6 +86,7 @@
         ],
         "Ibexa\\Bundle\\OAuth2Client\\IbexaOAuth2ClientBundle": ["all"],
         "Ibexa\\Bundle\\ProductCatalog\\IbexaProductCatalogBundle": ["all"],
+        "Ibexa\\Bundle\\ProductCatalogDateTimeAttribute\\IbexaProductCatalogDateTimeAttributeBundle": ["all"],
         "Ibexa\\Bundle\\Taxonomy\\IbexaTaxonomyBundle": ["all"],
         "Ibexa\\Bundle\\TreeBuilder\\IbexaTreeBuilderBundle": ["all"],
         "Ibexa\\Bundle\\ContentTree\\IbexaContentTreeBundle": ["all"],

--- a/ibexa/headless/5.0/manifest.json
+++ b/ibexa/headless/5.0/manifest.json
@@ -75,6 +75,7 @@
         ],
         "Ibexa\\Bundle\\OAuth2Client\\IbexaOAuth2ClientBundle": ["all"],
         "Ibexa\\Bundle\\ProductCatalog\\IbexaProductCatalogBundle": ["all"],
+        "Ibexa\\Bundle\\ProductCatalogDateTimeAttribute\\IbexaProductCatalogDateTimeAttributeBundle": ["all"],
         "Ibexa\\Bundle\\Taxonomy\\IbexaTaxonomyBundle": ["all"],
         "Ibexa\\Bundle\\TreeBuilder\\IbexaTreeBuilderBundle": ["all"],
         "Ibexa\\Bundle\\ContentTree\\IbexaContentTreeBundle": ["all"],

--- a/ibexa/product-catalog-date-time-attribute/5.0/manifest.json
+++ b/ibexa/product-catalog-date-time-attribute/5.0/manifest.json
@@ -1,9 +1,4 @@
 {
   "aliases": [],
-  "bundles": {
-    "Ibexa\\Bundle\\ProductCatalogDateTimeAttribute\\IbexaProductCatalogDateTimeAttributeBundle": ["all"]
-  },
-  "copy-from-recipe": {
-    "config/": "%CONFIG_DIR%/"
-  }
+  "bundles": {}
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-9957 |
|----------------|----------|

#### Description:
This pull request updates the recipe manifest for the product-catalog-date-and-time-attribute package by removing automatic bundle registration.

- Set the "bundles" section in manifest.json to an empty object ({}).
- Added this bundle to the edition manifests (commerce, expr, headless) to ensure proper loading based on project edition.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
