### PR TITLE
IBX-9960: Shifted autoloading of ibexa/connector-ai and ibexa/connector-openai from recipe to edition manifests

### DIFF
--- a/ibexa/commerce/5.0/manifest.json
+++ b/ibexa/commerce/5.0/manifest.json
@@ -74,6 +74,8 @@
         "Ibexa\\Bundle\\Elasticsearch\\IbexaElasticsearchBundle": ["all"],
         "Ibexa\\Bundle\\Permissions\\IbexaPermissionsBundle": ["all"],
         "Ibexa\\Bundle\\Connector\\Dam\\IbexaConnectorDamBundle": ["all"],
+        "Ibexa\\Bundle\\ConnectorAi\\IbexaConnectorAiBundle": ["all"],
+        "Ibexa\\Bundle\\ConnectorOpenAi\\IbexaConnectorOpenAiBundle": ["all"],
         "Ibexa\\Bundle\\Segmentation\\IbexaSegmentationBundle": ["all"],
         "Ibexa\\Bundle\\Personalization\\IbexaPersonalizationBundle": ["all"],
         "Ibexa\\Bundle\\Seo\\IbexaSeoBundle": ["all"],

--- a/ibexa/connector-ai/5.0/manifest.json
+++ b/ibexa/connector-ai/5.0/manifest.json
@@ -1,8 +1,6 @@
 {
   "aliases": [],
-  "bundles": {
-    "Ibexa\\Bundle\\ConnectorAi\\IbexaConnectorAiBundle": ["all"]
-  },
+  "bundles": {},
   "copy-from-recipe": {
     "config/": "%CONFIG_DIR%/"
   }

--- a/ibexa/connector-openai/5.0/manifest.json
+++ b/ibexa/connector-openai/5.0/manifest.json
@@ -3,7 +3,5 @@
   "env": {
     "OPENAI_API_KEY": "sk-123456"
   },
-  "bundles": {
-    "Ibexa\\Bundle\\ConnectorOpenAi\\IbexaConnectorOpenAiBundle": ["all"]
-  }
+  "bundles": {}
 }

--- a/ibexa/experience/5.0/manifest.json
+++ b/ibexa/experience/5.0/manifest.json
@@ -69,6 +69,8 @@
         "Ibexa\\Bundle\\Elasticsearch\\IbexaElasticsearchBundle": ["all"],
         "Ibexa\\Bundle\\Permissions\\IbexaPermissionsBundle": ["all"],
         "Ibexa\\Bundle\\Connector\\Dam\\IbexaConnectorDamBundle": ["all"],
+        "Ibexa\\Bundle\\ConnectorAi\\IbexaConnectorAiBundle": ["all"],
+        "Ibexa\\Bundle\\ConnectorOpenAi\\IbexaConnectorOpenAiBundle": ["all"],
         "Ibexa\\Bundle\\Segmentation\\IbexaSegmentationBundle": ["all"],
         "Ibexa\\Bundle\\Personalization\\IbexaPersonalizationBundle": ["all"],
         "Ibexa\\Bundle\\Seo\\IbexaSeoBundle": ["all"],

--- a/ibexa/headless/5.0/manifest.json
+++ b/ibexa/headless/5.0/manifest.json
@@ -59,6 +59,8 @@
         "Ibexa\\Bundle\\Icons\\IbexaIconsBundle": ["all"],
         "Ibexa\\Bundle\\Elasticsearch\\IbexaElasticsearchBundle": ["all"],
         "Ibexa\\Bundle\\Connector\\Dam\\IbexaConnectorDamBundle": ["all"],
+        "Ibexa\\Bundle\\ConnectorAi\\IbexaConnectorAiBundle": ["all"],
+        "Ibexa\\Bundle\\ConnectorOpenAi\\IbexaConnectorOpenAiBundle": ["all"],
         "Ibexa\\Bundle\\Personalization\\IbexaPersonalizationBundle": ["all"],
         "Ibexa\\Bundle\\Seo\\IbexaSeoBundle": ["all"],
         "Ibexa\\Bundle\\Measurement\\IbexaMeasurementBundle": ["all"],


### PR DESCRIPTION
| :ticket: Issue | IBX-9960 |
|----------------|----------|

#### Description:
This pull request updates the product core recipe manifest by removing automatic bundle registration for the ibexa/connector-ai and ibexa/connector-openai packages.

- Cleared the "bundles" section in manifest.json to stop auto-loading these bundles.
- Added these bundles to the edition manifests (commerce, expr, headless) to ensure proper loading based on project edition.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
