### PR TITLE
 IBX-10139: Removed duplicated content type icons and icon sets definitions 

### DIFF
--- a/ibexa/commerce/5.0/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/commerce/5.0/config/packages/ibexa_admin_ui.yaml
@@ -33,10 +33,6 @@ ibexa:
                 media: /1/43/
             page_builder:
                 siteaccess_list: [ site ]
-            assets:
-                icon_sets:
-                    ids_icons: /bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg
-                default_icon_set: ids_icons
             user_content_type_identifier: ['user', 'customer', 'member', 'editor']
             user_profile:
                 enabled: true

--- a/ibexa/commerce/5.0/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/commerce/5.0/config/packages/ibexa_admin_ui.yaml
@@ -37,43 +37,6 @@ ibexa:
                 icon_sets:
                     ids_icons: /bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg
                 default_icon_set: ids_icons
-            content_type:
-                about:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#info-square'
-                article:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#file-text'
-                blog:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#app-blog'
-                blog_post:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#note-blog'
-                editor:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#user-editor'
-                folder:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#folder'
-                form:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#form-checkbox-square'
-                place:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#pin-location'
-                product:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#product'
-                field:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#form-input'
-                user:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#user'
-                user_group:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#user-group'
-                file:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#file'
-                gallery:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#image-gallery'
-                image:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#image'
-                video:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#video-play'
-                landing_page:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#layout-navbar'
-                default-config:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#file'
             user_content_type_identifier: ['user', 'customer', 'member', 'editor']
             user_profile:
                 enabled: true

--- a/ibexa/experience/5.0/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/experience/5.0/config/packages/ibexa_admin_ui.yaml
@@ -33,10 +33,6 @@ ibexa:
                 media: /1/43/
             page_builder:
                 siteaccess_list: [site]
-            assets:
-                icon_sets:
-                    ids_icons: /bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg
-                default_icon_set: ids_icons
             user_content_type_identifier: ['user', 'editor']
             user_profile:
                 enabled: true

--- a/ibexa/experience/5.0/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/experience/5.0/config/packages/ibexa_admin_ui.yaml
@@ -37,43 +37,6 @@ ibexa:
                 icon_sets:
                     ids_icons: /bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg
                 default_icon_set: ids_icons
-            content_type:
-                about:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#info-square'
-                article:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#file-text'
-                blog:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#app-blog'
-                blog_post:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#note-blog'
-                editor:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#user-editor'
-                folder:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#folder'
-                form:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#form-checkbox-square'
-                place:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#pin-location'
-                product:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#product'
-                field:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#form-input'
-                user:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#user'
-                user_group:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#user-group'
-                file:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#file'
-                gallery:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#image-gallery'
-                image:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#image'
-                video:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#video-play'
-                landing_page:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#layout-navbar'
-                default-config:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#file'
             user_content_type_identifier: ['user', 'editor']
             user_profile:
                 enabled: true

--- a/ibexa/headless/5.0/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/headless/5.0/config/packages/ibexa_admin_ui.yaml
@@ -28,10 +28,6 @@ ibexa:
             subtree_paths:
                 content: /1/2/
                 media: /1/43/
-            assets:
-                icon_sets:
-                    ids_icons: /bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg
-                default_icon_set: ids_icons
             user_content_type_identifier: ['user', 'editor']
             user_profile:
                 enabled: true

--- a/ibexa/headless/5.0/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/headless/5.0/config/packages/ibexa_admin_ui.yaml
@@ -32,43 +32,6 @@ ibexa:
                 icon_sets:
                     ids_icons: /bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg
                 default_icon_set: ids_icons
-            content_type:
-                about:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#info-square'
-                article:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#file-text'
-                blog:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#app-blog'
-                blog_post:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#note-blog'
-                editor:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#user-editor'
-                folder:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#folder'
-                form:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#form-checkbox-square'
-                place:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#pin-location'
-                product:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#product'
-                field:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#form-input'
-                user:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#user'
-                user_group:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#user-group'
-                file:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#file'
-                gallery:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#image-gallery'
-                image:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#image'
-                video:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#video-play'
-                landing_page:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#layout-navbar'
-                default-config:
-                    thumbnail: '/bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg#file'
             user_content_type_identifier: ['user', 'editor']
             user_profile:
                 enabled: true

--- a/ibexa/oss/5.0/config/packages/ibexa_admin_ui.yaml
+++ b/ibexa/oss/5.0/config/packages/ibexa_admin_ui.yaml
@@ -27,10 +27,6 @@ ibexa:
             subtree_paths:
                 content: /1/2/
                 media: /1/43/
-            assets:
-                icon_sets:
-                    ids_icons: /bundles/ibexaadminuiassets/vendors/ids-assets/dist/img/all-icons.svg
-                default_icon_set: ids_icons
             default_page: 'dashboard'
             content:
                 default_ttl: 0


### PR DESCRIPTION
| :ticket: Issue | IBX-10139 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
As of 5.0 we will have one icon set, so we do not need to override content types icons from admin-ui to change them to premium ones (configuration will be taken from https://github.com/ibexa/admin-ui/blob/main/src/bundle/Resources/config/default_parameters.yaml#L2)

Also there is no need to change icon set per edition because we have one. (configuration will be taken from for example https://github.com/ibexa/recipes-dev/blob/master/ibexa/oss/5.0/config/packages/ibexa.yaml#L86) - I assume we do not have to specify it for "admin_group" and "default" is enough.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
