### PR TITLE
Made Ibexa DXP webpack modules work properly with symlinks

### DIFF
--- a/ibexa/commerce/4.6/encore/ibexa.webpack.custom.configs.js
+++ b/ibexa/commerce/4.6/encore/ibexa.webpack.custom.configs.js
@@ -1,7 +1,12 @@
+const Encore = require('@symfony/webpack-encore');
 const customConfigs = require('./var/encore/ibexa.webpack.custom.config.js');
 
 module.exports = customConfigs.reduce((configs, customConfigPath) => {
     let customConfig = require(customConfigPath);
+
+    if (typeof customConfig === 'function') {
+        customConfig = customConfig(Encore);
+    }
 
     if (!Array.isArray(customConfig)) {
         customConfig = [customConfig];

--- a/ibexa/commerce/5.0/encore/ibexa.webpack.custom.configs.js
+++ b/ibexa/commerce/5.0/encore/ibexa.webpack.custom.configs.js
@@ -1,7 +1,12 @@
+const Encore = require('@symfony/webpack-encore');
 const customConfigs = require('./var/encore/ibexa.webpack.custom.config.js');
 
 module.exports = customConfigs.reduce((configs, customConfigPath) => {
     let customConfig = require(customConfigPath);
+
+    if (typeof customConfig === 'function') {
+        customConfig = customConfig(Encore);
+    }
 
     if (!Array.isArray(customConfig)) {
         customConfig = [customConfig];

--- a/ibexa/experience/4.6/encore/ibexa.webpack.custom.configs.js
+++ b/ibexa/experience/4.6/encore/ibexa.webpack.custom.configs.js
@@ -1,7 +1,12 @@
+const Encore = require('@symfony/webpack-encore');
 const customConfigs = require('./var/encore/ibexa.webpack.custom.config.js');
 
 module.exports = customConfigs.reduce((configs, customConfigPath) => {
     let customConfig = require(customConfigPath);
+
+    if (typeof customConfig === 'function') {
+        customConfig = customConfig(Encore);
+    }
 
     if (!Array.isArray(customConfig)) {
         customConfig = [customConfig];

--- a/ibexa/experience/5.0/encore/ibexa.webpack.custom.configs.js
+++ b/ibexa/experience/5.0/encore/ibexa.webpack.custom.configs.js
@@ -1,7 +1,12 @@
+const Encore = require('@symfony/webpack-encore');
 const customConfigs = require('./var/encore/ibexa.webpack.custom.config.js');
 
 module.exports = customConfigs.reduce((configs, customConfigPath) => {
     let customConfig = require(customConfigPath);
+
+    if (typeof customConfig === 'function') {
+        customConfig = customConfig(Encore);
+    }
 
     if (!Array.isArray(customConfig)) {
         customConfig = [customConfig];

--- a/ibexa/headless/4.6/encore/ibexa.webpack.custom.configs.js
+++ b/ibexa/headless/4.6/encore/ibexa.webpack.custom.configs.js
@@ -1,7 +1,12 @@
+const Encore = require('@symfony/webpack-encore');
 const customConfigs = require('./var/encore/ibexa.webpack.custom.config.js');
 
 module.exports = customConfigs.reduce((configs, customConfigPath) => {
     let customConfig = require(customConfigPath);
+
+    if (typeof customConfig === 'function') {
+        customConfig = customConfig(Encore);
+    }
 
     if (!Array.isArray(customConfig)) {
         customConfig = [customConfig];

--- a/ibexa/headless/5.0/encore/ibexa.webpack.custom.configs.js
+++ b/ibexa/headless/5.0/encore/ibexa.webpack.custom.configs.js
@@ -1,7 +1,12 @@
+const Encore = require('@symfony/webpack-encore');
 const customConfigs = require('./var/encore/ibexa.webpack.custom.config.js');
 
 module.exports = customConfigs.reduce((configs, customConfigPath) => {
     let customConfig = require(customConfigPath);
+
+    if (typeof customConfig === 'function') {
+        customConfig = customConfig(Encore);
+    }
 
     if (!Array.isArray(customConfig)) {
         customConfig = [customConfig];

--- a/ibexa/oss/4.6/encore/ibexa.webpack.custom.configs.js
+++ b/ibexa/oss/4.6/encore/ibexa.webpack.custom.configs.js
@@ -1,7 +1,12 @@
+const Encore = require('@symfony/webpack-encore');
 const customConfigs = require('./var/encore/ibexa.webpack.custom.config.js');
 
 module.exports = customConfigs.reduce((configs, customConfigPath) => {
     let customConfig = require(customConfigPath);
+
+    if (typeof customConfig === 'function') {
+        customConfig = customConfig(Encore);
+    }
 
     if (!Array.isArray(customConfig)) {
         customConfig = [customConfig];

--- a/ibexa/oss/5.0/encore/ibexa.webpack.custom.configs.js
+++ b/ibexa/oss/5.0/encore/ibexa.webpack.custom.configs.js
@@ -1,7 +1,12 @@
+const Encore = require('@symfony/webpack-encore');
 const customConfigs = require('./var/encore/ibexa.webpack.custom.config.js');
 
 module.exports = customConfigs.reduce((configs, customConfigPath) => {
     let customConfig = require(customConfigPath);
+
+    if (typeof customConfig === 'function') {
+        customConfig = customConfig(Encore);
+    }
 
     if (!Array.isArray(customConfig)) {
         customConfig = [customConfig];


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR fixes an issue that happens when developing frontend code using packages symlinked by Composer.

![image](https://github.com/user-attachments/assets/749182f3-fa3e-4207-ba1d-691b184aaa01)

Issue stems from the fact that subpackage tries to load their own instance of `@symfony/webpack-encore`. Under normal circumstances (without symlinks) the project's one is selected. However, with symlinks, that module is no longer reachable - as it does not appear in any of the parent directories of package directory (since it resides elsewhere entirely).

To prevent this issue, I propose that we expect `webpack.config.js` modules exported from the package to be callables instead (in actuality, allow the to be callables). The exported function would expect to receive an instance of Symfony's Encore as first argument. This also ensures that they will actually receive a global Encore object.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
