### PR TITLE
IBX-7845: Removed IbexaIconsBundle from 5.0 recipes

### DIFF
--- a/ibexa/commerce/5.0/manifest.json
+++ b/ibexa/commerce/5.0/manifest.json
@@ -63,7 +63,6 @@
             "all"
         ],
         "Ibexa\\Bundle\\Search\\IbexaSearchBundle": ["all"],
-        "Ibexa\\Bundle\\Icons\\IbexaIconsBundle": ["all"],
         "Ibexa\\Bundle\\Installer\\IbexaInstallerBundle": ["all"],
         "Ibexa\\Bundle\\Notifications\\IbexaNotificationsBundle": ["all"],
         "Overblog\\GraphQLBundle\\OverblogGraphQLBundle": ["all"],

--- a/ibexa/experience/5.0/manifest.json
+++ b/ibexa/experience/5.0/manifest.json
@@ -65,7 +65,6 @@
             "all"
         ],
         "Ibexa\\Bundle\\Installer\\IbexaInstallerBundle": ["all"],
-        "Ibexa\\Bundle\\Icons\\IbexaIconsBundle": ["all"],
         "Ibexa\\Bundle\\Elasticsearch\\IbexaElasticsearchBundle": ["all"],
         "Ibexa\\Bundle\\Permissions\\IbexaPermissionsBundle": ["all"],
         "Ibexa\\Bundle\\Connector\\Dam\\IbexaConnectorDamBundle": ["all"],

--- a/ibexa/headless/5.0/manifest.json
+++ b/ibexa/headless/5.0/manifest.json
@@ -56,7 +56,6 @@
             "all"
         ],
         "Ibexa\\Bundle\\Installer\\IbexaInstallerBundle": ["all"],
-        "Ibexa\\Bundle\\Icons\\IbexaIconsBundle": ["all"],
         "Ibexa\\Bundle\\Elasticsearch\\IbexaElasticsearchBundle": ["all"],
         "Ibexa\\Bundle\\Connector\\Dam\\IbexaConnectorDamBundle": ["all"],
         "Ibexa\\Bundle\\Personalization\\IbexaPersonalizationBundle": ["all"],


### PR DESCRIPTION
| :ticket: Issue | IBX-7845 |
|----------------|-----------|

 
#### Related PRs: 
- https://github.com/ibexa/headless/pull/206


#### Description:

Removed obsolete IbexaIconsBundle from meta-packages recipes for 5.0.