### PR TITLE
IBX-10292: Commented out default league_oauth2_server configuration

### DIFF
--- a/ibexa/commerce/5.0/config/packages/league_oauth2_server.yaml
+++ b/ibexa/commerce/5.0/config/packages/league_oauth2_server.yaml
@@ -1,0 +1,17 @@
+#league_oauth2_server:
+#    authorization_server:
+#        private_key: '%env(resolve:OAUTH_PRIVATE_KEY)%'
+#        private_key_passphrase: '%env(resolve:OAUTH_PASSPHRASE)%'
+#        encryption_key: '%env(resolve:OAUTH_ENCRYPTION_KEY)%'
+#    resource_server:
+#        public_key: '%env(resolve:OAUTH_PUBLIC_KEY)%'
+#    scopes:
+#        available: ['email']
+#        default: ['email']
+#    persistence:
+#        doctrine: null
+
+when@test:
+    league_oauth2_server:
+        persistence:
+            in_memory: null

--- a/ibexa/experience/5.0/config/packages/league_oauth2_server.yaml
+++ b/ibexa/experience/5.0/config/packages/league_oauth2_server.yaml
@@ -1,0 +1,17 @@
+#league_oauth2_server:
+#    authorization_server:
+#        private_key: '%env(resolve:OAUTH_PRIVATE_KEY)%'
+#        private_key_passphrase: '%env(resolve:OAUTH_PASSPHRASE)%'
+#        encryption_key: '%env(resolve:OAUTH_ENCRYPTION_KEY)%'
+#    resource_server:
+#        public_key: '%env(resolve:OAUTH_PUBLIC_KEY)%'
+#    scopes:
+#        available: ['email']
+#        default: ['email']
+#    persistence:
+#        doctrine: null
+
+when@test:
+    league_oauth2_server:
+        persistence:
+            in_memory: null

--- a/ibexa/headless/5.0/config/packages/league_oauth2_server.yaml
+++ b/ibexa/headless/5.0/config/packages/league_oauth2_server.yaml
@@ -1,0 +1,17 @@
+#league_oauth2_server:
+#    authorization_server:
+#        private_key: '%env(resolve:OAUTH_PRIVATE_KEY)%'
+#        private_key_passphrase: '%env(resolve:OAUTH_PASSPHRASE)%'
+#        encryption_key: '%env(resolve:OAUTH_ENCRYPTION_KEY)%'
+#    resource_server:
+#        public_key: '%env(resolve:OAUTH_PUBLIC_KEY)%'
+#    scopes:
+#        available: ['email']
+#        default: ['email']
+#    persistence:
+#        doctrine: null
+
+when@test:
+    league_oauth2_server:
+        persistence:
+            in_memory: null


### PR DESCRIPTION
| :ticket: Issue | IBX-10292 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
In particular, this part:

```
persistence:
       doctrine: null
```

messed up our custom persistance configuration from `ibexa_oauth2_server.yaml`.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
In documentation, https://doc.ibexa.co/en/latest/users/oauth_server/#resource-server-configuration, that part is no longer valid. There is no need anymore for additional firewall - as mentioned in https://github.com/ibexa/recipes-dev/pull/135/files, all that should be required is to remove that oauth2 comment.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
