### PR TITLE
IBX-10284: Changed default CACHE_NAMESPACE from ezp to ibexa

### DIFF
--- a/ibexa/commerce/5.0/manifest.json
+++ b/ibexa/commerce/5.0/manifest.json
@@ -130,7 +130,7 @@
         "#8": "- https://symfony.com/doc/4.4/components/cache/adapters/redis_adapter.html#configure-the-connection",
         "#9": "- https://symfony.com/doc/4.4/components/cache/adapters/memcached_adapter.html#configure-the-connection",
         "CACHE_DSN": "localhost",
-        "CACHE_NAMESPACE": "ezp",
+        "CACHE_NAMESPACE": "ibexa",
         "DATABASE_CHARSET": "utf8mb4",
         "DATABASE_COLLATION": "utf8mb4_unicode_520_ci",
         "#10": "Needed by Doctrine Bundle / ORM to prevent it from opening a connection during situations where there is no service yet.",

--- a/ibexa/experience/5.0/manifest.json
+++ b/ibexa/experience/5.0/manifest.json
@@ -123,7 +123,7 @@
         "#8": "- https://symfony.com/doc/4.4/components/cache/adapters/redis_adapter.html#configure-the-connection",
         "#9": "- https://symfony.com/doc/4.4/components/cache/adapters/memcached_adapter.html#configure-the-connection",
         "CACHE_DSN": "localhost",
-        "CACHE_NAMESPACE": "ezp",
+        "CACHE_NAMESPACE": "ibexa",
         "DATABASE_CHARSET": "utf8mb4",
         "DATABASE_COLLATION": "utf8mb4_unicode_520_ci",
         "#10": "Needed by Doctrine Bundle / ORM to prevent it from opening a connection during situations where there is no service yet.",

--- a/ibexa/headless/5.0/manifest.json
+++ b/ibexa/headless/5.0/manifest.json
@@ -108,7 +108,7 @@
         "#8": "- https://symfony.com/doc/4.4/components/cache/adapters/redis_adapter.html#configure-the-connection",
         "#9": "- https://symfony.com/doc/4.4/components/cache/adapters/memcached_adapter.html#configure-the-connection",
         "CACHE_DSN": "localhost",
-        "CACHE_NAMESPACE": "ezp",
+        "CACHE_NAMESPACE": "ibexa",
         "DATABASE_CHARSET": "utf8mb4",
         "DATABASE_COLLATION": "utf8mb4_unicode_520_ci",
         "#10": "Needed by Doctrine Bundle / ORM to prevent it from opening a connection during situations where there is no service yet.",


### PR DESCRIPTION
| :ticket: Issue | IBX-10284 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Aligned CACHE_NAMESPACE with ibexa/oss. 

#### For QA:
N/A

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
