### PR TITLE
IBX-10640: Changed order of assets compilation

### DIFF
--- a/ibexa/commerce/5.0/manifest.json
+++ b/ibexa/commerce/5.0/manifest.json
@@ -168,7 +168,7 @@
         "yarn ibexa-generate-tsconfig --use-relative-paths": "script",
         "ibexa:encore:compile --config-name app": "symfony-cmd",
         "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
-        "ibexa:encore:compile": "symfony-cmd",
-        "ibexa:encore:compile --frontend-configs-name ibexa,internals,libs,richtext": "symfony-cmd"
+        "ibexa:encore:compile --frontend-configs-name ibexa,internals,libs,richtext": "symfony-cmd",
+        "ibexa:encore:compile": "symfony-cmd"
     }
 }

--- a/ibexa/experience/5.0/manifest.json
+++ b/ibexa/experience/5.0/manifest.json
@@ -161,7 +161,7 @@
         "yarn ibexa-generate-tsconfig --use-relative-paths": "script",
         "ibexa:encore:compile --config-name app": "symfony-cmd",
         "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
-        "ibexa:encore:compile": "symfony-cmd",
-        "ibexa:encore:compile --frontend-configs-name ibexa,internals,libs,richtext": "symfony-cmd"
+        "ibexa:encore:compile --frontend-configs-name ibexa,internals,libs,richtext": "symfony-cmd",
+        "ibexa:encore:compile": "symfony-cmd"
     }
 }

--- a/ibexa/headless/5.0/manifest.json
+++ b/ibexa/headless/5.0/manifest.json
@@ -142,7 +142,7 @@
         "yarn ibexa-generate-tsconfig --use-relative-paths": "script",
         "ibexa:encore:compile --config-name app": "symfony-cmd",
         "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
-        "ibexa:encore:compile": "symfony-cmd",
-        "ibexa:encore:compile --frontend-configs-name ibexa,internals,libs,richtext": "symfony-cmd"
+        "ibexa:encore:compile --frontend-configs-name ibexa,internals,libs,richtext": "symfony-cmd",
+        "ibexa:encore:compile": "symfony-cmd"
     }
 }

--- a/ibexa/oss/5.0/manifest.json
+++ b/ibexa/oss/5.0/manifest.json
@@ -93,7 +93,7 @@
     "yarn ibexa-generate-tsconfig --use-relative-paths": "script",
     "ibexa:encore:compile --config-name app": "symfony-cmd",
     "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
-    "ibexa:encore:compile": "symfony-cmd",
-    "ibexa:encore:compile --frontend-configs-name ibexa,internals,libs,richtext": "symfony-cmd"
+    "ibexa:encore:compile --frontend-configs-name ibexa,internals,libs,richtext": "symfony-cmd",
+    "ibexa:encore:compile": "symfony-cmd"
   }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-10640 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Moved the `webpack.config.js` assets compilation (ibexa:encore:compile)  to the final step of the build process (auto-scripts). This ensures that backoffice code can be extended.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
