### PR TITLE
IBX-11671: Added `enabled` field to Quable connector default configuration

### DIFF
--- a/ibexa/connector-quable/5.0/config/packages/ibexa_connector_quable.yaml
+++ b/ibexa/connector-quable/5.0/config/packages/ibexa_connector_quable.yaml
@@ -1,4 +1,7 @@
-# ibexa_connector_quable:
+ibexa_connector_quable:
+    ### Fill in connection details and you can remove "enabled" field. It will become enabled automatically.
+    enabled: false
+
     # instance_url: ~
     # api_token: ~
     # webhook_secret: ~

--- a/ibexa/connector-quable/6.0/config/packages/ibexa_connector_quable.yaml
+++ b/ibexa/connector-quable/6.0/config/packages/ibexa_connector_quable.yaml
@@ -1,4 +1,7 @@
-# ibexa_connector_quable:
+ibexa_connector_quable:
+    ### Fill in connection details and you can remove "enabled" field. It will become enabled automatically.
+    enabled: false
+
     # instance_url: ~
     # api_token: ~
     # webhook_secret: ~


### PR DESCRIPTION
| :ticket: Issue | IBX-11671 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Due to changes in Symfony (`auto_enabled` attribute when `ConfigBuilder::canBeEnabled()` is used) we need to explicitly start with bundle disabled until configured.

Without this recipe, the bundle "enables itself" due to default settings being present (in bundle itself).

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
