### PR TITLE
IBX-11766: [ibexa/behat] Added tests/bootstrap.php and adjusted manifest.json

### DIFF
--- a/ibexa/behat/5.0/manifest.json
+++ b/ibexa/behat/5.0/manifest.json
@@ -11,6 +11,7 @@
         "behat_ibexa_commerce.yaml": "behat_ibexa_commerce.yaml"
     },
     "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/"
+        "config/": "%CONFIG_DIR%/",
+        "tests/": "tests/"
     }
 }

--- a/ibexa/behat/5.0/tests/bootstrap.php
+++ b/ibexa/behat/5.0/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__) . '/vendor/autoload.php';

--- a/ibexa/behat/5.0/tests/bootstrap.php
+++ b/ibexa/behat/5.0/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+if (method_exists(Dotenv::class, 'bootEnv')) {
+    (new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');
+}
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+}

--- a/ibexa/behat/5.0/tests/bootstrap.php
+++ b/ibexa/behat/5.0/tests/bootstrap.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Symfony\Component\Dotenv\Dotenv;
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');

--- a/ibexa/behat/6.0/manifest.json
+++ b/ibexa/behat/6.0/manifest.json
@@ -11,6 +11,7 @@
         "behat_ibexa_commerce.yaml": "behat_ibexa_commerce.yaml"
     },
     "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/"
+        "config/": "%CONFIG_DIR%/",
+        "tests/": "tests/"
     }
 }

--- a/ibexa/behat/6.0/tests/bootstrap.php
+++ b/ibexa/behat/6.0/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__) . '/vendor/autoload.php';

--- a/ibexa/behat/6.0/tests/bootstrap.php
+++ b/ibexa/behat/6.0/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+if (method_exists(Dotenv::class, 'bootEnv')) {
+    (new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');
+}
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+}

--- a/ibexa/behat/6.0/tests/bootstrap.php
+++ b/ibexa/behat/6.0/tests/bootstrap.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Symfony\Component\Dotenv\Dotenv;
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');


### PR DESCRIPTION
| :ticket: Issue | [IBX-11766](https://ibexa.atlassian.net/browse/IBX-11766) |
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/behat/pull/184

#### Description:
This PR adds `test/bootstrap.php`, which is part of the official `phpunit/phpunit` recipe. After moving `phpunit` package from prod to dev dependencies in `ibexa/behat` (https://github.com/ibexa/behat/pull/184), this file is not installed and behat tests are failing because we're relying on this file in [config](https://github.com/ibexa/behat/blob/6.0/behat_ibexa_oss.yaml#L46).

#### For QA:
#### Documentation:

[IBX-11766]: https://ibexa.atlassian.net/browse/IBX-11766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ