### PR TITLE
IBX-11816: Command yarn encore prod returns an error

### DIFF
--- a/ibexa/commerce/4.6/encore/package.json
+++ b/ibexa/commerce/4.6/encore/package.json
@@ -29,7 +29,8 @@
     "react-dom": "^18.2.0"
   },
   "resolutions": {
-    "@types/glob": "8.1.0"
+    "@types/glob": "8.1.0",
+    "webpack-sources": "^3.5.0"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/experience/4.6/encore/package.json
+++ b/ibexa/experience/4.6/encore/package.json
@@ -29,7 +29,8 @@
     "react-dom": "^18.2.0"
   },
   "resolutions": {
-    "@types/glob": "8.1.0"
+    "@types/glob": "8.1.0",
+    "webpack-sources": "^3.5.0"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/headless/4.6/encore/package.json
+++ b/ibexa/headless/4.6/encore/package.json
@@ -25,7 +25,8 @@
     "@svgr/webpack": "^8.1.0"
   },
   "resolutions": {
-    "@types/glob": "8.1.0"
+    "@types/glob": "8.1.0",
+    "webpack-sources": "^3.5.0"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/oss/4.6/encore/package.json
+++ b/ibexa/oss/4.6/encore/package.json
@@ -24,7 +24,8 @@
     "@svgr/webpack": "^8.1.0"
   },
   "resolutions": {
-    "@types/glob": "8.1.0"
+    "@types/glob": "8.1.0",
+    "webpack-sources": "^3.5.0"
   },
   "license": "UNLICENSED",
   "private": true,


### PR DESCRIPTION
| :ticket: Issue | IBX-11816 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
 The issue occurs only in production because `terser-webpack-plugin` (minifier) runs exclusively during encore production.
The problem is versions conflict of `webpack-sources`. `@ckeditor/ckeditor5-dev-translations` requires ^2.x
while `symfony/webpack` requires ^3.x. Yarn installs both versions side by side. When `terser-webpack-plugin` calls `.node()` on those children, it crashes because `webpack-sources` v2 objects don't have that method.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
