### PR TITLE
IBX-12105: [ibexa/documentation-developer] Added recipe for documentation package

### DIFF
--- a/ibexa/documentation-developer/5.0/manifest.json
+++ b/ibexa/documentation-developer/5.0/manifest.json
@@ -3,6 +3,6 @@
   "bundles": {},
   "copy-from-package": {
     ".agents/skills/external/": ".agents/skills/",
-   "./.agents/skills/external/ibexa-documentation/SKILL.md": ".claude/skills/ibexa-documentation/SKILL.md"
+   "./.agents/skills/external/ibexa-documentation/": ".claude/skills/ibexa-documentation/"
   }
 }

--- a/ibexa/documentation-developer/5.0/manifest.json
+++ b/ibexa/documentation-developer/5.0/manifest.json
@@ -1,0 +1,7 @@
+{
+  "aliases": [],
+  "bundles": {},
+  "copy-from-package": {
+    ".agents/skills/external/": ".agents/skills/ibexa/"
+  }
+}

--- a/ibexa/documentation-developer/5.0/manifest.json
+++ b/ibexa/documentation-developer/5.0/manifest.json
@@ -3,6 +3,6 @@
   "bundles": {},
   "copy-from-package": {
     ".agents/skills/external/": ".agents/skills/",
-    ".agents/skills/external/ibexa-documentation/": ".claude/skills/ibexa-documentation/"
+    ".agents/skills/external/ibexa-documentation/SKILL.md": ".claude/skills/ibexa-documentation/SKILL.md"
   }
 }

--- a/ibexa/documentation-developer/5.0/manifest.json
+++ b/ibexa/documentation-developer/5.0/manifest.json
@@ -2,6 +2,7 @@
   "aliases": [],
   "bundles": {},
   "copy-from-package": {
-    ".agents/skills/external/": ".agents/skills/ibexa/"
+    ".agents/skills/external/": ".agents/skills/",
+    ".agents/skills/external/ibexa-documentation/": ".claude/skills/ibexa-documentation/"
   }
 }

--- a/ibexa/documentation-developer/5.0/manifest.json
+++ b/ibexa/documentation-developer/5.0/manifest.json
@@ -3,6 +3,6 @@
   "bundles": {},
   "copy-from-package": {
     ".agents/skills/external/": ".agents/skills/",
-    ".agents/skills/external/ibexa-documentation/SKILL.md": ".claude/skills/ibexa-documentation/SKILL.md"
+   "./.agents/skills/external/ibexa-documentation/SKILL.md": ".claude/skills/ibexa-documentation/SKILL.md"
   }
 }


### PR DESCRIPTION
Recipe copying the "ibexa-documentation" skill to the project.

For more information, see https://github.com/ibexa/documentation-developer/pull/3307

Sadly, even though Antrophic created the Agent Skills spec (https://agentskills.io/home) and the spec gives the `.agents/skills/` directory as the place to store skills (https://agentskills.io/skill-creation/quickstart), Claude does not follow it.

Most agents support `.agents/skill`, Claude does not.
You can see the list here: https://github.com/agentskills/agentskills/issues/15

So, this recipe copies the skill twice:
- once to the directory almost all agents support
- second time to the `.claude` specific directory

Because the key in JSON cannot be duplicated, for the first case we can copy the whole directory and for the second one we copy skill-by-skill.

Tested locally:

``` bash
~/De/Sites/experience-skeleton main !3 ❯ composer sync-recipes ibexa/documentation-developer --force --reset -v
ComposerCheckout plugin activated.

Symfony operations: 1 recipe (7cd5305b29411b4366aab49714823ffc)
  - Configuring ibexa/documentation-developer (>=5.0): From github.com/ibexa/recipes-dev:master
    Enabling the package as a Symfony bundle
    Copying files from package
      Created "./.agents/skills/ibexa-documentation/"
      Created "./.agents/skills/ibexa-documentation/SKILL.md"
      Created "./.claude/skills/ibexa-documentation/"
      Created "./.claude/skills/ibexa-documentation/SKILL.md"
```
