### PR TITLE
IBX-12091: Added typescript-estree to frontend dependencies

### DIFF
--- a/ibexa/commerce/6.0/encore/package.json
+++ b/ibexa/commerce/6.0/encore/package.json
@@ -11,6 +11,7 @@
     "@symfony/webpack-encore": "^5.1.0",
     "@types/react-dom": "^19.1.2",
     "@types/react": "^19.1.2",
+    "@typescript-eslint/typescript-estree": "^8.62.1",
     "ckeditor5": "^45.0.0",
     "core-js": "^3.0.0",
     "file-loader": "^6.0.0",

--- a/ibexa/experience/6.0/encore/package.json
+++ b/ibexa/experience/6.0/encore/package.json
@@ -11,6 +11,7 @@
     "@symfony/webpack-encore": "^5.1.0",
     "@types/react-dom": "^19.1.2",
     "@types/react": "^19.1.2",
+    "@typescript-eslint/typescript-estree": "^8.62.1",
     "ckeditor5": "^45.0.0",
     "core-js": "^3.0.0",
     "file-loader": "^6.0.0",

--- a/ibexa/headless/6.0/encore/package.json
+++ b/ibexa/headless/6.0/encore/package.json
@@ -11,6 +11,7 @@
     "@symfony/webpack-encore": "^5.1.0",
     "@types/react-dom": "^19.1.2",
     "@types/react": "^19.1.2",
+    "@typescript-eslint/typescript-estree": "^8.62.1",
     "ckeditor5": "^45.0.0",
     "core-js": "^3.0.0",
     "file-loader": "^6.0.0",

--- a/ibexa/oss/6.0/encore/package.json
+++ b/ibexa/oss/6.0/encore/package.json
@@ -11,6 +11,7 @@
     "@symfony/webpack-encore": "^5.1.0",
     "@types/react-dom": "^19.1.2",
     "@types/react": "^19.1.2",
+    "@typescript-eslint/typescript-estree": "^8.62.1",
     "ckeditor5": "^45.0.0",
     "core-js": "^3.0.0",
     "file-loader": "^6.0.0",


### PR DESCRIPTION
| :ticket: Issue | IBX-12091 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/admin-ui/pull/1986
- https://github.com/ibexa/gh-workflows/pull/106


#### Description:
`ibexa/admin-ui` extracts translations from TypeScript with a Node script importing `@typescript-eslint/typescript-estree`. Composer cannot install npm packages, so `bin/console translation:extract` currently fails in a freshly installed project.
Adding the package to `encore/package.json` makes the documented installation provision it: `post-update-cmd` runs `auto-scripts`, which already runs `yarn install`. Node then resolves the parser from the project's `node_modules`.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
