### PR TITLE
IBX-11964: Stop registering IbexaAppSwitcherBundle in the 6.0 edition recipes

### DIFF
--- a/ibexa/commerce/6.0/manifest.json
+++ b/ibexa/commerce/6.0/manifest.json
@@ -102,7 +102,6 @@
         "Ibexa\\Bundle\\Dashboard\\IbexaDashboardBundle": ["all"],
         "Ibexa\\Bundle\\SiteContext\\IbexaSiteContextBundle": ["all"],
         "Ibexa\\Bundle\\HeadlessAssets\\IbexaHeadlessAssetsBundle": ["all"],
-        "Ibexa\\Bundle\\AppSwitcher\\IbexaAppSwitcherBundle": ["all"],
         "Ibexa\\Bundle\\TwigComponents\\IbexaTwigComponentsBundle": ["all"],
         "Ibexa\\Bundle\\Messenger\\IbexaMessengerBundle": ["all"]
     },

--- a/ibexa/experience/6.0/manifest.json
+++ b/ibexa/experience/6.0/manifest.json
@@ -95,7 +95,6 @@
         "Ibexa\\Bundle\\Dashboard\\IbexaDashboardBundle": ["all"],
         "Ibexa\\Bundle\\SiteContext\\IbexaSiteContextBundle": ["all"],
         "Ibexa\\Bundle\\HeadlessAssets\\IbexaHeadlessAssetsBundle": ["all"],
-        "Ibexa\\Bundle\\AppSwitcher\\IbexaAppSwitcherBundle": ["all"],
         "Ibexa\\Bundle\\TwigComponents\\IbexaTwigComponentsBundle": ["all"],
         "Ibexa\\Bundle\\Messenger\\IbexaMessengerBundle": ["all"]
     },

--- a/ibexa/headless/6.0/manifest.json
+++ b/ibexa/headless/6.0/manifest.json
@@ -80,7 +80,6 @@
         "Ibexa\\Bundle\\ImagePicker\\IbexaImagePickerBundle": ["all"],
         "Ibexa\\Bundle\\SiteContext\\IbexaSiteContextBundle": ["all"],
         "Ibexa\\Bundle\\HeadlessAssets\\IbexaHeadlessAssetsBundle": ["all"],
-        "Ibexa\\Bundle\\AppSwitcher\\IbexaAppSwitcherBundle": ["all"],
         "Ibexa\\Bundle\\TwigComponents\\IbexaTwigComponentsBundle": ["all"],
         "Ibexa\\Bundle\\Messenger\\IbexaMessengerBundle": ["all"]
     },


### PR DESCRIPTION
| :ticket: Issue | IBX-11964 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/headless/pull/298 + https://github.com/ibexa/engage/pull/7 — drop the `ibexa/app-switcher` requirement.
- **Merge this one FIRST**: their browser tests generate fresh projects, and with the recipe still registering `IbexaAppSwitcherBundle` the projects die at `cache:clear` with "Class not found" (that's the current red CI on #298).

#### Description:

Removes `IbexaAppSwitcherBundle` from the 6.0 headless/experience/commerce recipe manifests, as part of retiring the Qntm app switcher (superseded by the native one, ibexa/admin-ui#1997). 4.6/5.0 recipes are untouched — the package stays on released versions.

#### For QA:

Fresh 6.0 project installs get no `IbexaAppSwitcherBundle` line in `config/bundles.php`. Existing projects keep the line until they remove the package (composer + bundles.php cleanup on their side).

#### Documentation:
